### PR TITLE
Use context everywhere

### DIFF
--- a/context_test.go
+++ b/context_test.go
@@ -32,9 +32,7 @@ func TestWithNotCanceledContext(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer cancel()
 
-	withCtx := dbmap.WithContext(ctx)
-
-	_, err := withCtx.Exec("SELECT 1")
+	_, err := dbmap.ExecContext(ctx, "SELECT 1")
 	assert.Nil(t, err)
 }
 
@@ -55,11 +53,9 @@ func TestWithCanceledContext(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer cancel()
 
-	withCtx := dbmap.WithContext(ctx)
-
 	startTime := time.Now()
 
-	_, err := withCtx.Exec("SELECT " + sleepDialect.SleepClause(1*time.Second))
+	_, err := dbmap.ExecContext(ctx, "SELECT "+sleepDialect.SleepClause(1*time.Second))
 
 	if d := time.Since(startTime); d > 500*time.Millisecond {
 		t.Errorf("too long execution time: %s", d)

--- a/db.go
+++ b/db.go
@@ -798,7 +798,7 @@ func (m *DbMap) QueryRowContext(ctx context.Context, query string, args ...inter
 		now := time.Now()
 		defer m.trace(now, query, args...)
 	}
-	return queryRow(ctx, m, query, args...)
+	return m.Db.QueryRowContext(ctx, query, args...)
 }
 
 func (m *DbMap) QueryContext(ctx context.Context, q string, args ...interface{}) (*sql.Rows, error) {
@@ -810,7 +810,7 @@ func (m *DbMap) QueryContext(ctx context.Context, q string, args ...interface{})
 		now := time.Now()
 		defer m.trace(now, q, args...)
 	}
-	return query(ctx, m, q, args...)
+	return m.Db.QueryContext(ctx, q, args...)
 }
 
 func (m *DbMap) trace(started time.Time, query string, args ...interface{}) {

--- a/db.go
+++ b/db.go
@@ -598,7 +598,7 @@ func (m *DbMap) Select(ctx context.Context, i interface{}, query string, args ..
 }
 
 // Exec runs an arbitrary SQL statement.  args represent the bind parameters.
-// This is equivalent to running:  Exec() using database/sql
+// This is equivalent to running:  ExecContext() using database/sql
 func (m *DbMap) ExecContext(ctx context.Context, query string, args ...interface{}) (sql.Result, error) {
 	if m.ExpandSliceArgs {
 		expandSliceArgs(&query, args...)
@@ -735,7 +735,7 @@ func (m *DbMap) DynamicTableFor(tableName string, checkPK bool) (*TableMap, erro
 
 // Prepare creates a prepared statement for later queries or executions.
 // Multiple queries or executions may be run concurrently from the returned statement.
-// This is equivalent to running:  Prepare() using database/sql
+// This is equivalent to running:  PrepareContext() using database/sql
 func (m *DbMap) PrepareContext(ctx context.Context, query string) (*sql.Stmt, error) {
 	if m.logger != nil {
 		now := time.Now()
@@ -789,6 +789,7 @@ func (m *DbMap) tableForPointer(ptr interface{}, checkPK bool) (*TableMap, refle
 	return t, elem, nil
 }
 
+// This is equivalent to running:  QueryRowContext() using database/sql
 func (m *DbMap) QueryRowContext(ctx context.Context, query string, args ...interface{}) *sql.Row {
 	if m.ExpandSliceArgs {
 		expandSliceArgs(&query, args...)
@@ -801,6 +802,7 @@ func (m *DbMap) QueryRowContext(ctx context.Context, query string, args ...inter
 	return m.Db.QueryRowContext(ctx, query, args...)
 }
 
+// This is equivalent to running:  QueryContext() using database/sql
 func (m *DbMap) QueryContext(ctx context.Context, q string, args ...interface{}) (*sql.Rows, error) {
 	if m.ExpandSliceArgs {
 		expandSliceArgs(&q, args...)

--- a/db_test.go
+++ b/db_test.go
@@ -108,7 +108,7 @@ AND field12 IN (:FieldIntList)
 	dbmap.ExpandSliceArgs = true
 	dbmap.AddTableWithName(dataFormat{}, "crazy_table")
 
-	err := dbmap.CreateTables()
+	err := dbmap.CreateTables(context.Background())
 	if err != nil {
 		panic(err)
 	}

--- a/db_test.go
+++ b/db_test.go
@@ -8,6 +8,7 @@
 package borp_test
 
 import (
+	"context"
 	"testing"
 )
 
@@ -114,6 +115,7 @@ AND field12 IN (:FieldIntList)
 	defer dropAndClose(dbmap)
 
 	err = dbmap.Insert(
+		context.Background(),
 		&dataFormat{
 			Field1:  123,
 			Field2:  "h",
@@ -171,7 +173,7 @@ AND field12 IN (:FieldIntList)
 	for _, tt := range tests {
 		t.Run(tt.description, func(t *testing.T) {
 			var dummy []int
-			_, err := dbmap.Select(&dummy, tt.query, tt.args...)
+			_, err := dbmap.Select(context.Background(), &dummy, tt.query, tt.args...)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/dialect.go
+++ b/dialect.go
@@ -84,7 +84,7 @@ type TargetedAutoIncrInserter interface {
 	// automatically generated primary key directly to the passed in
 	// target.  The target should be a pointer to the primary key
 	// field of the value being inserted.
-	InsertAutoIncrToTarget(ectx context.Context, xec SqlExecutor, insertSql string, target interface{}, params ...interface{}) error
+	InsertAutoIncrToTarget(ctx context.Context, xec SqlExecutor, insertSql string, target interface{}, params ...interface{}) error
 }
 
 // TargetQueryInserter is implemented by dialects that can perform
@@ -94,7 +94,7 @@ type TargetQueryInserter interface {
 	// TargetQueryInserter runs an insert operation and assigns the
 	// automatically generated primary key retrived by the query
 	// extracted from the GeneratedIdQuery field of the id column.
-	InsertQueryToTarget(ectx context.Context, xec SqlExecutor, insertSql, idSql string, target interface{}, params ...interface{}) error
+	InsertQueryToTarget(ctx context.Context, xec SqlExecutor, insertSql, idSql string, target interface{}, params ...interface{}) error
 }
 
 func standardInsertAutoIncr(ctx context.Context, exec SqlExecutor, insertSql string, params ...interface{}) (int64, error) {

--- a/dialect.go
+++ b/dialect.go
@@ -73,7 +73,7 @@ type Dialect interface {
 // the dialect can handle automatic assignment of more than just
 // integers, see TargetedAutoIncrInserter.
 type IntegerAutoIncrInserter interface {
-	InsertAutoIncr(exec SqlExecutor, insertSql string, params ...interface{}) (int64, error)
+	InsertAutoIncr(ctx context.Context, exec SqlExecutor, insertSql string, params ...interface{}) (int64, error)
 }
 
 // TargetedAutoIncrInserter is implemented by dialects that can
@@ -84,7 +84,7 @@ type TargetedAutoIncrInserter interface {
 	// automatically generated primary key directly to the passed in
 	// target.  The target should be a pointer to the primary key
 	// field of the value being inserted.
-	InsertAutoIncrToTarget(exec SqlExecutor, insertSql string, target interface{}, params ...interface{}) error
+	InsertAutoIncrToTarget(ectx context.Context, xec SqlExecutor, insertSql string, target interface{}, params ...interface{}) error
 }
 
 // TargetQueryInserter is implemented by dialects that can perform
@@ -94,7 +94,7 @@ type TargetQueryInserter interface {
 	// TargetQueryInserter runs an insert operation and assigns the
 	// automatically generated primary key retrived by the query
 	// extracted from the GeneratedIdQuery field of the id column.
-	InsertQueryToTarget(exec SqlExecutor, insertSql, idSql string, target interface{}, params ...interface{}) error
+	InsertQueryToTarget(ectx context.Context, xec SqlExecutor, insertSql, idSql string, target interface{}, params ...interface{}) error
 }
 
 func standardInsertAutoIncr(ctx context.Context, exec SqlExecutor, insertSql string, params ...interface{}) (int64, error) {

--- a/dialect.go
+++ b/dialect.go
@@ -5,6 +5,7 @@
 package borp
 
 import (
+	"context"
 	"reflect"
 )
 
@@ -96,8 +97,8 @@ type TargetQueryInserter interface {
 	InsertQueryToTarget(exec SqlExecutor, insertSql, idSql string, target interface{}, params ...interface{}) error
 }
 
-func standardInsertAutoIncr(exec SqlExecutor, insertSql string, params ...interface{}) (int64, error) {
-	res, err := exec.Exec(insertSql, params...)
+func standardInsertAutoIncr(ctx context.Context, exec SqlExecutor, insertSql string, params ...interface{}) (int64, error) {
+	res, err := exec.ExecContext(ctx, insertSql, params...)
 	if err != nil {
 		return 0, err
 	}

--- a/dialect_mysql.go
+++ b/dialect_mysql.go
@@ -5,6 +5,7 @@
 package borp
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 	"strings"
@@ -140,8 +141,8 @@ func (d MySQLDialect) BindVar(i int) string {
 	return "?"
 }
 
-func (d MySQLDialect) InsertAutoIncr(exec SqlExecutor, insertSql string, params ...interface{}) (int64, error) {
-	return standardInsertAutoIncr(exec, insertSql, params...)
+func (d MySQLDialect) InsertAutoIncr(ctx context.Context, exec SqlExecutor, insertSql string, params ...interface{}) (int64, error) {
+	return standardInsertAutoIncr(ctx, exec, insertSql, params...)
 }
 
 func (d MySQLDialect) QuoteField(f string) string {

--- a/dialect_sqlite.go
+++ b/dialect_sqlite.go
@@ -5,6 +5,7 @@
 package borp
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 )
@@ -86,8 +87,8 @@ func (d SqliteDialect) BindVar(i int) string {
 	return "?"
 }
 
-func (d SqliteDialect) InsertAutoIncr(exec SqlExecutor, insertSql string, params ...interface{}) (int64, error) {
-	return standardInsertAutoIncr(exec, insertSql, params...)
+func (d SqliteDialect) InsertAutoIncr(ctx context.Context, exec SqlExecutor, insertSql string, params ...interface{}) (int64, error) {
+	return standardInsertAutoIncr(ctx, exec, insertSql, params...)
 }
 
 func (d SqliteDialect) QuoteField(f string) string {

--- a/gorp.go
+++ b/gorp.go
@@ -84,7 +84,7 @@ type SqlExecutor interface {
 	// But since these three functions delegate to functions of the same name on *sql.DB, it would be
 	// a little confusing if we had, e.g. `Exec` (taking a context), which delegates to
 	// `sql.DB.ExecContext` (taking a context) as opposed to `sql.DB.Exec` (taking no context).
-	// So we don't both with `Context` in the name for Get, Insert, etc., but we do for these.
+	// So we don't bother with `Context` in the name for Get, Insert, etc., but we do for these.
 	ExecContext(ctx context.Context, query string, args ...interface{}) (sql.Result, error)
 	QueryContext(ctx context.Context, query string, args ...interface{}) (*sql.Rows, error)
 	QueryRowContext(ctx context.Context, query string, args ...interface{}) *sql.Row

--- a/gorp.go
+++ b/gorp.go
@@ -555,7 +555,7 @@ func insert(ctx context.Context, m *DbMap, exec SqlExecutor, list ...interface{}
 			f := elem.FieldByName(bi.autoIncrFieldName)
 			switch inserter := m.Dialect.(type) {
 			case IntegerAutoIncrInserter:
-				id, err := inserter.InsertAutoIncr(exec, bi.query, bi.args...)
+				id, err := inserter.InsertAutoIncr(ctx, exec, bi.query, bi.args...)
 				if err != nil {
 					return err
 				}
@@ -568,7 +568,7 @@ func insert(ctx context.Context, m *DbMap, exec SqlExecutor, list ...interface{}
 					return fmt.Errorf("gorp: cannot set autoincrement value on non-Int field. SQL=%s  autoIncrIdx=%d autoIncrFieldName=%s", bi.query, bi.autoIncrIdx, bi.autoIncrFieldName)
 				}
 			case TargetedAutoIncrInserter:
-				err := inserter.InsertAutoIncrToTarget(exec, bi.query, f.Addr().Interface(), bi.args...)
+				err := inserter.InsertAutoIncrToTarget(ctx, exec, bi.query, f.Addr().Interface(), bi.args...)
 				if err != nil {
 					return err
 				}
@@ -577,7 +577,7 @@ func insert(ctx context.Context, m *DbMap, exec SqlExecutor, list ...interface{}
 				if idQuery == "" {
 					return fmt.Errorf("gorp: cannot set %s value if its ColumnMap.GeneratedIdQuery is empty", bi.autoIncrFieldName)
 				}
-				err := inserter.InsertQueryToTarget(exec, bi.query, idQuery, f.Addr().Interface(), bi.args...)
+				err := inserter.InsertQueryToTarget(ctx, exec, bi.query, idQuery, f.Addr().Interface(), bi.args...)
 				if err != nil {
 					return err
 				}

--- a/gorp.go
+++ b/gorp.go
@@ -150,9 +150,9 @@ func maybeExpandNamedQueryAndExec(ctx context.Context, e SqlExecutor, query stri
 		return m.Db.ExecContext(ctx, query, args...)
 	case *Transaction:
 		return m.tx.ExecContext(ctx, query, args...)
+	default:
+		return nil, fmt.Errorf("gorp: unknown SqlExecutor type: %T", m)
 	}
-
-	return e.ExecContext(ctx, query, args...)
 }
 
 func extractDbMap(e SqlExecutor) *DbMap {

--- a/gorp.go
+++ b/gorp.go
@@ -79,7 +79,12 @@ type SqlExecutor interface {
 	SelectNullStr(ctx context.Context, query string, args ...interface{}) (sql.NullString, error)
 	SelectOne(ctx context.Context, holder interface{}, query string, args ...interface{}) error
 
-	// These method signatures are shared with *sql.DB
+	// These method signatures are shared with *sql.DB.
+	// Stylistically, `Context` in the name is redundant. It is the future, everything takes a context.
+	// But since these three functions delegate to functions of the same name on *sql.DB, it would be
+	// a little confusing if we had, e.g. `Exec` (taking a context), which delegates to
+	// `sql.DB.ExecContext` (taking a context) as opposed to `sql.DB.Exec` (taking no context).
+	// So we don't both with `Context` in the name for Get, Insert, etc., but we do for these.
 	ExecContext(ctx context.Context, query string, args ...interface{}) (sql.Result, error)
 	QueryContext(ctx context.Context, query string, args ...interface{}) (*sql.Rows, error)
 	QueryRowContext(ctx context.Context, query string, args ...interface{}) *sql.Row

--- a/gorp_test.go
+++ b/gorp_test.go
@@ -675,7 +675,7 @@ func TestCreateTablesIfNotExists(t *testing.T) {
 	dbmap := initDBMap(t)
 	defer dropAndClose(dbmap)
 
-	err := dbmap.CreateTablesIfNotExists()
+	err := dbmap.CreateTablesIfNotExists(context.Background())
 	if err != nil {
 		t.Error(err)
 	}
@@ -684,7 +684,7 @@ func TestCreateTablesIfNotExists(t *testing.T) {
 func TestTruncateTables(t *testing.T) {
 	dbmap := initDBMap(t)
 	defer dropAndClose(dbmap)
-	err := dbmap.CreateTablesIfNotExists()
+	err := dbmap.CreateTablesIfNotExists(context.Background())
 	if err != nil {
 		t.Error(err)
 	}
@@ -695,7 +695,7 @@ func TestTruncateTables(t *testing.T) {
 	inv := &Invoice{0, 0, 1, "my invoice", 0, true}
 	dbmap.Insert(context.Background(), inv)
 
-	err = dbmap.TruncateTables()
+	err = dbmap.TruncateTables(context.Background())
 	if err != nil {
 		t.Error(err)
 	}
@@ -715,7 +715,7 @@ func TestCustomDateType(t *testing.T) {
 	dbmap := newDBMap(t)
 	dbmap.TypeConverter = testTypeConverter{}
 	dbmap.AddTable(WithCustomDate{}).SetKeys(true, "Id")
-	err := dbmap.CreateTables()
+	err := dbmap.CreateTables(context.Background())
 	if err != nil {
 		panic(err)
 	}
@@ -752,7 +752,7 @@ func TestUIntPrimaryKey(t *testing.T) {
 	dbmap.AddTable(PersonUInt64{}).SetKeys(true, "Id")
 	dbmap.AddTable(PersonUInt32{}).SetKeys(true, "Id")
 	dbmap.AddTable(PersonUInt16{}).SetKeys(true, "Id")
-	err := dbmap.CreateTablesIfNotExists()
+	err := dbmap.CreateTablesIfNotExists(context.Background())
 	if err != nil {
 		panic(err)
 	}
@@ -779,7 +779,7 @@ func TestUIntPrimaryKey(t *testing.T) {
 func TestSetUniqueTogether(t *testing.T) {
 	dbmap := newDBMap(t)
 	dbmap.AddTable(UniqueColumns{}).SetUniqueTogether("FirstName", "LastName").SetUniqueTogether("City", "ZipCode")
-	err := dbmap.CreateTablesIfNotExists()
+	err := dbmap.CreateTablesIfNotExists(context.Background())
 	if err != nil {
 		panic(err)
 	}
@@ -827,7 +827,7 @@ func TestSetUniqueTogetherIdempotent(t *testing.T) {
 	dbmap := newDBMap(t)
 	table := dbmap.AddTable(UniqueColumns{}).SetUniqueTogether("FirstName", "LastName")
 	table.SetUniqueTogether("FirstName", "LastName")
-	err := dbmap.CreateTablesIfNotExists()
+	err := dbmap.CreateTablesIfNotExists(context.Background())
 	if err != nil {
 		panic(err)
 	}
@@ -858,7 +858,7 @@ func TestPersistentUser(t *testing.T) {
 	dbmap.ExecContext(context.Background(), "drop table if exists PersistentUser")
 	table := dbmap.AddTable(PersistentUser{}).SetKeys(false, "Key")
 	table.ColMap("Key").Rename("mykey")
-	err := dbmap.CreateTablesIfNotExists()
+	err := dbmap.CreateTablesIfNotExists(context.Background())
 	if err != nil {
 		panic(err)
 	}
@@ -970,7 +970,7 @@ func TestNamedQueryMap(t *testing.T) {
 	dbmap.ExecContext(context.Background(), "drop table if exists PersistentUser")
 	table := dbmap.AddTable(PersistentUser{}).SetKeys(false, "Key")
 	table.ColMap("Key").Rename("mykey")
-	err := dbmap.CreateTablesIfNotExists()
+	err := dbmap.CreateTablesIfNotExists(context.Background())
 	if err != nil {
 		panic(err)
 	}
@@ -1067,7 +1067,7 @@ func TestNamedQueryStruct(t *testing.T) {
 	dbmap.ExecContext(context.Background(), "drop table if exists PersistentUser")
 	table := dbmap.AddTable(PersistentUser{}).SetKeys(false, "Key")
 	table.ColMap("Key").Rename("mykey")
-	err := dbmap.CreateTablesIfNotExists()
+	err := dbmap.CreateTablesIfNotExists(context.Background())
 	if err != nil {
 		panic(err)
 	}
@@ -1133,7 +1133,7 @@ func TestReturnsNonNilSlice(t *testing.T) {
 func TestOverrideVersionCol(t *testing.T) {
 	dbmap := newDBMap(t)
 	t1 := dbmap.AddTable(InvoicePersonView{}).SetKeys(false, "InvoiceId", "PersonId")
-	err := dbmap.CreateTables()
+	err := dbmap.CreateTables(context.Background())
 	if err != nil {
 		panic(err)
 	}
@@ -1248,7 +1248,7 @@ func TestScannerValuer(t *testing.T) {
 	dbmap := newDBMap(t)
 	dbmap.AddTableWithName(PersonValuerScanner{}, "person_test").SetKeys(true, "Id")
 	dbmap.AddTableWithName(InvoiceWithValuer{}, "invoice_test").SetKeys(true, "Id")
-	err := dbmap.CreateTables()
+	err := dbmap.CreateTables(context.Background())
 	if err != nil {
 		panic(err)
 	}
@@ -1292,7 +1292,7 @@ func TestColumnProps(t *testing.T) {
 	t1.ColMap("Memo").SetMaxSize(10)
 	t1.ColMap("PersonId").SetUnique(true)
 
-	err := dbmap.CreateTables()
+	err := dbmap.CreateTables(context.Background())
 	if err != nil {
 		panic(err)
 	}
@@ -2054,7 +2054,7 @@ func TestEmbeddedTime(t *testing.T) {
 	dbmap := newDBMap(t)
 	dbmap.AddTable(EmbeddedTime{}).SetKeys(false, "Id")
 	defer dropAndClose(dbmap)
-	err := dbmap.CreateTables()
+	err := dbmap.CreateTables(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2352,22 +2352,22 @@ func TestMysqlPanicIfDialectNotInitialized(t *testing.T) {
 	db := &borp.DbMap{Db: connect(driver), Dialect: dialect}
 	db.AddTableWithName(Invoice{}, "invoice")
 	// the following call should panic :
-	db.CreateTables()
+	db.CreateTables(context.Background())
 }
 
 func TestSingleColumnKeyDbReturnsZeroRowsUpdatedOnPKChange(t *testing.T) {
 	dbmap := initDBMap(t)
 	defer dropAndClose(dbmap)
 	dbmap.AddTableWithName(SingleColumnTable{}, "single_column_table").SetKeys(false, "SomeId")
-	err := dbmap.DropTablesIfExists()
+	err := dbmap.DropTablesIfExists(context.Background())
 	if err != nil {
 		t.Error("Drop tables failed")
 	}
-	err = dbmap.CreateTablesIfNotExists()
+	err = dbmap.CreateTablesIfNotExists(context.Background())
 	if err != nil {
 		t.Error("Create tables failed")
 	}
-	err = dbmap.TruncateTables()
+	err = dbmap.TruncateTables(context.Background())
 	if err != nil {
 		t.Error("Truncate tables failed")
 	}
@@ -2460,7 +2460,7 @@ func TestCallOfValueMethodOnNilPointer(t *testing.T) {
 	dbmap := newDBMap(t)
 	dbmap.AddTable(NilPointer{}).SetKeys(false, "ID")
 	defer dropAndClose(dbmap)
-	err := dbmap.CreateTables()
+	err := dbmap.CreateTables(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2570,7 +2570,7 @@ func initDBMapBench(b *testing.B) *borp.DbMap {
 	dbmap := newDBMap(b)
 	dbmap.Db.ExecContext(context.Background(), "drop table if exists invoice_test")
 	dbmap.AddTableWithName(Invoice{}, "invoice_test").SetKeys(true, "Id")
-	err := dbmap.CreateTables()
+	err := dbmap.CreateTables(context.Background())
 	if err != nil {
 		panic(err)
 	}
@@ -2597,16 +2597,16 @@ func initDBMap(t *testing.T) *borp.DbMap {
 	dbmap.AddTableWithName(WithTime{}, "time_test").SetKeys(true, "Id")
 	dbmap.AddTableWithName(WithNullTime{}, "nulltime_test").SetKeys(false, "Id")
 	dbmap.TypeConverter = testTypeConverter{}
-	err := dbmap.DropTablesIfExists()
+	err := dbmap.DropTablesIfExists(context.Background())
 	if err != nil {
 		panic(err)
 	}
-	err = dbmap.CreateTables()
+	err = dbmap.CreateTables(context.Background())
 	if err != nil {
 		panic(err)
 	}
 
-	err = dbmap.CreateIndex()
+	err = dbmap.CreateIndex(context.Background())
 	if err != nil {
 		panic(err)
 	}
@@ -2621,7 +2621,7 @@ func initDBMap(t *testing.T) *borp.DbMap {
 func initDBMapNulls(t *testing.T) *borp.DbMap {
 	dbmap := newDBMap(t)
 	dbmap.AddTable(TableWithNull{}).SetKeys(false, "Id")
-	err := dbmap.CreateTables()
+	err := dbmap.CreateTables(context.Background())
 	if err != nil {
 		panic(err)
 	}
@@ -2650,7 +2650,7 @@ func newDBMap(l Logger) *borp.DbMap {
 }
 
 func dropAndClose(dbmap *borp.DbMap) {
-	dbmap.DropTablesIfExists()
+	dbmap.DropTablesIfExists(context.Background())
 	dbmap.Db.Close()
 }
 

--- a/gorp_test.go
+++ b/gorp_test.go
@@ -9,6 +9,7 @@ package borp_test
 
 import (
 	"bytes"
+	"context"
 	"database/sql"
 	"database/sql/driver"
 	"encoding/json"
@@ -420,7 +421,7 @@ func dynamicTablesTest(t *testing.T, dbmap *borp.DbMap) {
 	// TEST - dbmap.Insert using dynTableInst1
 	dynTableInst1.Name = "Test Name 1"
 	dynTableInst1.Address = "Test Address 1"
-	err := dbmap.Insert(&dynTableInst1)
+	err := dbmap.Insert(context.Background(), &dynTableInst1)
 	if err != nil {
 		t.Errorf("Errow while saving dynTableInst1. Details: %v", err)
 	}
@@ -428,7 +429,7 @@ func dynamicTablesTest(t *testing.T, dbmap *borp.DbMap) {
 	// TEST - dbmap.Insert using dynTableInst2
 	dynTableInst2.Name = "Test Name 2"
 	dynTableInst2.Address = "Test Address 2"
-	err = dbmap.Insert(&dynTableInst2)
+	err = dbmap.Insert(context.Background(), &dynTableInst2)
 	if err != nil {
 		t.Errorf("Errow while saving dynTableInst2. Details: %v", err)
 	}
@@ -469,7 +470,7 @@ func dynamicTablesTestSelect(t *testing.T,
 	// table mapping is correct
 	var dbTenantInst1 = TenantDynamic{curTable: inpInst.curTable}
 	selectSQL1 := "select * from " + inpInst.curTable
-	dbObjs, err := dbmap.Select(&dbTenantInst1, selectSQL1)
+	dbObjs, err := dbmap.Select(context.Background(), &dbTenantInst1, selectSQL1)
 	if err != nil {
 		t.Errorf("Errow in dbmap.Select. SQL: %v, Details: %v", selectSQL1, err)
 	}
@@ -515,7 +516,7 @@ func dynamicTablesTestGetUpdateGet(t *testing.T,
 	// read and update one of the instances to make sure
 	// that the common gorp APIs are working well with dynamic table
 	var inpIface2 = TenantDynamic{curTable: inpInst.curTable}
-	dbObj, err := dbmap.Get(&inpIface2, inpInst.Id)
+	dbObj, err := dbmap.Get(context.Background(), &inpIface2, inpInst.Id)
 	if err != nil {
 		t.Errorf("Errow in dbmap.Get. id: %v, Details: %v", inpInst.Id, err)
 	}
@@ -552,7 +553,7 @@ func dynamicTablesTestGetUpdateGet(t *testing.T,
 	{
 		updatedName := "Testing Updated Name2"
 		dbInst.Name = updatedName
-		cnt, err := dbmap.Update(dbInst)
+		cnt, err := dbmap.Update(context.Background(), dbInst)
 		if err != nil {
 			t.Errorf("Error from dbmap.Update: %v", err.Error())
 		}
@@ -562,7 +563,7 @@ func dynamicTablesTestGetUpdateGet(t *testing.T,
 
 		// Read the object again to make sure that the
 		// data was updated in db
-		dbObj2, err := dbmap.Get(&inpIface2, inpInst.Id)
+		dbObj2, err := dbmap.Get(context.Background(), &inpIface2, inpInst.Id)
 		if err != nil {
 			t.Errorf("Errow in dbmap.Get. id: %v, Details: %v", inpInst.Id, err)
 		}
@@ -608,7 +609,7 @@ func dynamicTablesTestSelectOne(t *testing.T,
 	var dbTenantInst1 = TenantDynamic{curTable: inpInst.curTable}
 	selectSQL1 := "select * from " + dbTenantInst1.curTable + " where id = :idKey"
 	params := map[string]interface{}{"idKey": inpInst.Id}
-	err := dbmap.SelectOne(&dbTenantInst1, selectSQL1, params)
+	err := dbmap.SelectOne(context.Background(), &dbTenantInst1, selectSQL1, params)
 	if err != nil {
 		t.Errorf("Errow in dbmap.SelectOne. SQL: %v, Details: %v", selectSQL1, err)
 	}
@@ -641,7 +642,7 @@ func dynamicTablesTestDelete(t *testing.T,
 	inpInst *TenantDynamic) {
 
 	// TEST - dbmap.Delete
-	cnt, err := dbmap.Delete(inpInst)
+	cnt, err := dbmap.Delete(context.Background(), inpInst)
 	if err != nil {
 		t.Errorf("Errow in dbmap.Delete. Details: %v", err)
 	}
@@ -652,7 +653,7 @@ func dynamicTablesTestDelete(t *testing.T,
 
 	// Try reading again to make sure instance is gone from db
 	getInst := TenantDynamic{curTable: inpInst.TableName()}
-	dbInst, err := dbmap.Get(&getInst, inpInst.Id)
+	dbInst, err := dbmap.Get(context.Background(), &getInst, inpInst.Id)
 	if err != nil {
 		t.Errorf("Error while trying to read deleted %v object using id: %v",
 			inpInst.TableName(), inpInst.Id)
@@ -690,9 +691,9 @@ func TestTruncateTables(t *testing.T) {
 
 	// Insert some data
 	p1 := &Person{0, 0, 0, "Bob", "Smith", 0}
-	dbmap.Insert(p1)
+	dbmap.Insert(context.Background(), p1)
 	inv := &Invoice{0, 0, 1, "my invoice", 0, true}
-	dbmap.Insert(inv)
+	dbmap.Insert(context.Background(), inv)
 
 	err = dbmap.TruncateTables()
 	if err != nil {
@@ -700,11 +701,11 @@ func TestTruncateTables(t *testing.T) {
 	}
 
 	// Make sure all rows are deleted
-	rows, _ := dbmap.Select(Person{}, "SELECT * FROM person_test")
+	rows, _ := dbmap.Select(context.Background(), Person{}, "SELECT * FROM person_test")
 	if len(rows) != 0 {
 		t.Errorf("Expected 0 person rows, got %d", len(rows))
 	}
-	rows, _ = dbmap.Select(Invoice{}, "SELECT * FROM invoice_test")
+	rows, _ = dbmap.Select(context.Background(), Invoice{}, "SELECT * FROM invoice_test")
 	if len(rows) != 0 {
 		t.Errorf("Expected 0 invoice rows, got %d", len(rows))
 	}
@@ -721,7 +722,7 @@ func TestCustomDateType(t *testing.T) {
 	defer dropAndClose(dbmap)
 
 	test1 := &WithCustomDate{Added: CustomDate{Time: time.Now().Truncate(time.Second)}}
-	err = dbmap.Insert(test1)
+	err = dbmap.Insert(context.Background(), test1)
 	if err != nil {
 		t.Errorf("Could not insert struct with custom date field: %s", err)
 		t.FailNow()
@@ -735,7 +736,7 @@ func TestCustomDateType(t *testing.T) {
 	if _, driver := dialectAndDriver(); driver == "mysql" {
 		t.Skip("TestCustomDateType can't run Get() with the mysql driver; skipping the rest of this test...")
 	}
-	result, err := dbmap.Get(new(WithCustomDate), test1.Id)
+	result, err := dbmap.Get(context.Background(), new(WithCustomDate), test1.Id)
 	if err != nil {
 		t.Errorf("Could not get struct with custom date field: %s", err)
 		t.FailNow()
@@ -760,7 +761,7 @@ func TestUIntPrimaryKey(t *testing.T) {
 	p1 := &PersonUInt64{0, "name1"}
 	p2 := &PersonUInt32{0, "name2"}
 	p3 := &PersonUInt16{0, "name3"}
-	err = dbmap.Insert(p1, p2, p3)
+	err = dbmap.Insert(context.Background(), p1, p2, p3)
 	if err != nil {
 		t.Error(err)
 	}
@@ -785,14 +786,14 @@ func TestSetUniqueTogether(t *testing.T) {
 	defer dropAndClose(dbmap)
 
 	n1 := &UniqueColumns{"Steve", "Jobs", "Cupertino", 95014}
-	err = dbmap.Insert(n1)
+	err = dbmap.Insert(context.Background(), n1)
 	if err != nil {
 		t.Error(err)
 	}
 
 	// Should fail because of the first constraint
 	n2 := &UniqueColumns{"Steve", "Jobs", "Sunnyvale", 94085}
-	err = dbmap.Insert(n2)
+	err = dbmap.Insert(context.Background(), n2)
 	if err == nil {
 		t.Error(err)
 	}
@@ -804,7 +805,7 @@ func TestSetUniqueTogether(t *testing.T) {
 
 	// Should also fail because of the second unique-together
 	n3 := &UniqueColumns{"Steve", "Wozniak", "Cupertino", 95014}
-	err = dbmap.Insert(n3)
+	err = dbmap.Insert(context.Background(), n3)
 	if err == nil {
 		t.Error(err)
 	}
@@ -816,7 +817,7 @@ func TestSetUniqueTogether(t *testing.T) {
 
 	// This one should finally succeed
 	n4 := &UniqueColumns{"Steve", "Wozniak", "Sunnyvale", 94085}
-	err = dbmap.Insert(n4)
+	err = dbmap.Insert(context.Background(), n4)
 	if err != nil {
 		t.Error(err)
 	}
@@ -833,14 +834,14 @@ func TestSetUniqueTogetherIdempotent(t *testing.T) {
 	defer dropAndClose(dbmap)
 
 	n1 := &UniqueColumns{"Steve", "Jobs", "Cupertino", 95014}
-	err = dbmap.Insert(n1)
+	err = dbmap.Insert(context.Background(), n1)
 	if err != nil {
 		t.Error(err)
 	}
 
 	// Should still fail because of the constraint
 	n2 := &UniqueColumns{"Steve", "Jobs", "Sunnyvale", 94085}
-	err = dbmap.Insert(n2)
+	err = dbmap.Insert(context.Background(), n2)
 	if err == nil {
 		t.Error(err)
 	}
@@ -854,7 +855,7 @@ func TestSetUniqueTogetherIdempotent(t *testing.T) {
 
 func TestPersistentUser(t *testing.T) {
 	dbmap := newDBMap(t)
-	dbmap.Exec("drop table if exists PersistentUser")
+	dbmap.ExecContext(context.Background(), "drop table if exists PersistentUser")
 	table := dbmap.AddTable(PersistentUser{}).SetKeys(false, "Key")
 	table.ColMap("Key").Rename("mykey")
 	err := dbmap.CreateTablesIfNotExists()
@@ -863,13 +864,13 @@ func TestPersistentUser(t *testing.T) {
 	}
 	defer dropAndClose(dbmap)
 	pu := &PersistentUser{43, "33r", false}
-	err = dbmap.Insert(pu)
+	err = dbmap.Insert(context.Background(), pu)
 	if err != nil {
 		panic(err)
 	}
 
 	// prove we can pass a pointer into Get
-	pu2, err := dbmap.Get(pu, pu.Key)
+	pu2, err := dbmap.Get(context.Background(), pu, pu.Key)
 	if err != nil {
 		panic(err)
 	}
@@ -877,7 +878,7 @@ func TestPersistentUser(t *testing.T) {
 		t.Errorf("%v!=%v", pu, pu2)
 	}
 
-	arr, err := dbmap.Select(pu, "select * from "+tableName(dbmap, PersistentUser{}))
+	arr, err := dbmap.Select(context.Background(), pu, "select * from "+tableName(dbmap, PersistentUser{}))
 	if err != nil {
 		panic(err)
 	}
@@ -887,7 +888,7 @@ func TestPersistentUser(t *testing.T) {
 
 	// prove we can get the results back in a slice
 	var puArr []*PersistentUser
-	_, err = dbmap.Select(&puArr, "select * from "+tableName(dbmap, PersistentUser{}))
+	_, err = dbmap.Select(context.Background(), &puArr, "select * from "+tableName(dbmap, PersistentUser{}))
 	if err != nil {
 		panic(err)
 	}
@@ -900,7 +901,7 @@ func TestPersistentUser(t *testing.T) {
 
 	// prove we can get the results back in a non-pointer slice
 	var puValues []PersistentUser
-	_, err = dbmap.Select(&puValues, "select * from "+tableName(dbmap, PersistentUser{}))
+	_, err = dbmap.Select(context.Background(), &puValues, "select * from "+tableName(dbmap, PersistentUser{}))
 	if err != nil {
 		panic(err)
 	}
@@ -913,7 +914,7 @@ func TestPersistentUser(t *testing.T) {
 
 	// prove we can get the results back in a string slice
 	var idArr []*string
-	_, err = dbmap.Select(&idArr, "select "+columnName(dbmap, PersistentUser{}, "Id")+" from "+tableName(dbmap, PersistentUser{}))
+	_, err = dbmap.Select(context.Background(), &idArr, "select "+columnName(dbmap, PersistentUser{}, "Id")+" from "+tableName(dbmap, PersistentUser{}))
 	if err != nil {
 		panic(err)
 	}
@@ -926,7 +927,7 @@ func TestPersistentUser(t *testing.T) {
 
 	// prove we can get the results back in an int slice
 	var keyArr []*int32
-	_, err = dbmap.Select(&keyArr, "select mykey from "+tableName(dbmap, PersistentUser{}))
+	_, err = dbmap.Select(context.Background(), &keyArr, "select mykey from "+tableName(dbmap, PersistentUser{}))
 	if err != nil {
 		panic(err)
 	}
@@ -939,7 +940,7 @@ func TestPersistentUser(t *testing.T) {
 
 	// prove we can get the results back in a bool slice
 	var passedArr []*bool
-	_, err = dbmap.Select(&passedArr, "select "+columnName(dbmap, PersistentUser{}, "PassedTraining")+" from "+tableName(dbmap, PersistentUser{}))
+	_, err = dbmap.Select(context.Background(), &passedArr, "select "+columnName(dbmap, PersistentUser{}, "PassedTraining")+" from "+tableName(dbmap, PersistentUser{}))
 	if err != nil {
 		panic(err)
 	}
@@ -952,7 +953,7 @@ func TestPersistentUser(t *testing.T) {
 
 	// prove we can get the results back in a non-pointer slice
 	var stringArr []string
-	_, err = dbmap.Select(&stringArr, "select "+columnName(dbmap, PersistentUser{}, "Id")+" from "+tableName(dbmap, PersistentUser{}))
+	_, err = dbmap.Select(context.Background(), &stringArr, "select "+columnName(dbmap, PersistentUser{}, "Id")+" from "+tableName(dbmap, PersistentUser{}))
 	if err != nil {
 		panic(err)
 	}
@@ -966,7 +967,7 @@ func TestPersistentUser(t *testing.T) {
 
 func TestNamedQueryMap(t *testing.T) {
 	dbmap := newDBMap(t)
-	dbmap.Exec("drop table if exists PersistentUser")
+	dbmap.ExecContext(context.Background(), "drop table if exists PersistentUser")
 	table := dbmap.AddTable(PersistentUser{}).SetKeys(false, "Key")
 	table.ColMap("Key").Rename("mykey")
 	err := dbmap.CreateTablesIfNotExists()
@@ -976,14 +977,14 @@ func TestNamedQueryMap(t *testing.T) {
 	defer dropAndClose(dbmap)
 	pu := &PersistentUser{43, "33r", false}
 	pu2 := &PersistentUser{500, "abc", false}
-	err = dbmap.Insert(pu, pu2)
+	err = dbmap.Insert(context.Background(), pu, pu2)
 	if err != nil {
 		panic(err)
 	}
 
 	// Test simple case
 	var puArr []*PersistentUser
-	_, err = dbmap.Select(&puArr, "select * from "+tableName(dbmap, PersistentUser{})+" where mykey = :Key", map[string]interface{}{
+	_, err = dbmap.Select(context.Background(), &puArr, "select * from "+tableName(dbmap, PersistentUser{})+" where mykey = :Key", map[string]interface{}{
 		"Key": 43,
 	})
 	if err != nil {
@@ -999,7 +1000,7 @@ func TestNamedQueryMap(t *testing.T) {
 
 	// Test more specific map value type is ok
 	puArr = nil
-	_, err = dbmap.Select(&puArr, "select * from "+tableName(dbmap, PersistentUser{})+" where mykey = :Key", map[string]int{
+	_, err = dbmap.Select(context.Background(), &puArr, "select * from "+tableName(dbmap, PersistentUser{})+" where mykey = :Key", map[string]int{
 		"Key": 43,
 	})
 	if err != nil {
@@ -1012,7 +1013,7 @@ func TestNamedQueryMap(t *testing.T) {
 
 	// Test multiple parameters set.
 	puArr = nil
-	_, err = dbmap.Select(&puArr, `
+	_, err = dbmap.Select(context.Background(), &puArr, `
 select * from `+tableName(dbmap, PersistentUser{})+`
  where mykey = :Key
    and `+columnName(dbmap, PersistentUser{}, "PassedTraining")+` = :PassedTraining
@@ -1032,7 +1033,7 @@ select * from `+tableName(dbmap, PersistentUser{})+`
 	// Test colon within a non-key string
 	// Test having extra, unused properties in the map.
 	puArr = nil
-	_, err = dbmap.Select(&puArr, `
+	_, err = dbmap.Select(context.Background(), &puArr, `
 select * from `+tableName(dbmap, PersistentUser{})+`
  where mykey = :Key
    and `+columnName(dbmap, PersistentUser{}, "Id")+` != 'abc:def'`, map[string]interface{}{
@@ -1047,8 +1048,8 @@ select * from `+tableName(dbmap, PersistentUser{})+`
 		t.Errorf("Expected one persistentuser, found none")
 	}
 
-	// Test to delete with Exec and named params.
-	result, err := dbmap.Exec("delete from "+tableName(dbmap, PersistentUser{})+" where mykey = :Key", map[string]interface{}{
+	// Test to delete with ExecContext and named params.
+	result, err := dbmap.ExecContext(context.Background(), "delete from "+tableName(dbmap, PersistentUser{})+" where mykey = :Key", map[string]interface{}{
 		"Key": 43,
 	})
 	count, err := result.RowsAffected()
@@ -1063,7 +1064,7 @@ select * from `+tableName(dbmap, PersistentUser{})+`
 
 func TestNamedQueryStruct(t *testing.T) {
 	dbmap := newDBMap(t)
-	dbmap.Exec("drop table if exists PersistentUser")
+	dbmap.ExecContext(context.Background(), "drop table if exists PersistentUser")
 	table := dbmap.AddTable(PersistentUser{}).SetKeys(false, "Key")
 	table.ColMap("Key").Rename("mykey")
 	err := dbmap.CreateTablesIfNotExists()
@@ -1073,14 +1074,14 @@ func TestNamedQueryStruct(t *testing.T) {
 	defer dropAndClose(dbmap)
 	pu := &PersistentUser{43, "33r", false}
 	pu2 := &PersistentUser{500, "abc", false}
-	err = dbmap.Insert(pu, pu2)
+	err = dbmap.Insert(context.Background(), pu, pu2)
 	if err != nil {
 		panic(err)
 	}
 
 	// Test select self
 	var puArr []*PersistentUser
-	_, err = dbmap.Select(&puArr, `
+	_, err = dbmap.Select(context.Background(), &puArr, `
 select * from `+tableName(dbmap, PersistentUser{})+`
  where mykey = :Key
    and `+columnName(dbmap, PersistentUser{}, "PassedTraining")+` = :PassedTraining
@@ -1097,7 +1098,7 @@ select * from `+tableName(dbmap, PersistentUser{})+`
 	}
 
 	// Test delete self.
-	result, err := dbmap.Exec(`
+	result, err := dbmap.ExecContext(context.Background(), `
 delete from `+tableName(dbmap, PersistentUser{})+`
  where mykey = :Key
    and `+columnName(dbmap, PersistentUser{}, "PassedTraining")+` = :PassedTraining
@@ -1154,7 +1155,7 @@ func TestOptimisticLocking(t *testing.T) {
 	defer dropAndClose(dbmap)
 
 	p1 := &Person{0, 0, 0, "Bob", "Smith", 0}
-	dbmap.Insert(p1) // Version is now 1
+	dbmap.Insert(context.Background(), p1) // Version is now 1
 	if p1.Version != 1 {
 		t.Errorf("Insert didn't incr Version: %d != %d", 1, p1.Version)
 		return
@@ -1164,19 +1165,19 @@ func TestOptimisticLocking(t *testing.T) {
 		return
 	}
 
-	obj, err := dbmap.Get(Person{}, p1.Id)
+	obj, err := dbmap.Get(context.Background(), Person{}, p1.Id)
 	if err != nil {
 		panic(err)
 	}
 	p2 := obj.(*Person)
 	p2.LName = "Edwards"
-	dbmap.Update(p2) // Version is now 2
+	dbmap.Update(context.Background(), p2) // Version is now 2
 	if p2.Version != 2 {
 		t.Errorf("Update didn't incr Version: %d != %d", 2, p2.Version)
 	}
 
 	p1.LName = "Howard"
-	count, err := dbmap.Update(p1)
+	count, err := dbmap.Update(context.Background(), p1)
 	if _, ok := err.(borp.OptimisticLockError); !ok {
 		t.Errorf("update - Expected borp.OptimisticLockError, got: %v", err)
 	}
@@ -1184,7 +1185,7 @@ func TestOptimisticLocking(t *testing.T) {
 		t.Errorf("update - Expected -1 count, got: %d", count)
 	}
 
-	count, err = dbmap.Delete(p1)
+	count, err = dbmap.Delete(context.Background(), p1)
 	if _, ok := err.(borp.OptimisticLockError); !ok {
 		t.Errorf("delete - Expected borp.OptimisticLockError, got: %v", err)
 	}
@@ -1256,7 +1257,7 @@ func TestScannerValuer(t *testing.T) {
 	pv := PersonValuerScanner{}
 	pv.FName = "foo"
 	pv.LName = "bar"
-	err = dbmap.Insert(&pv)
+	err = dbmap.Insert(context.Background(), &pv)
 	if err != nil {
 		t.Errorf("Could not insert PersonValuerScanner using Person table: %v", err)
 		t.FailNow()
@@ -1265,13 +1266,13 @@ func TestScannerValuer(t *testing.T) {
 	inv := InvoiceWithValuer{}
 	inv.Memo = "foo"
 	inv.Person = pv
-	err = dbmap.Insert(&inv)
+	err = dbmap.Insert(context.Background(), &inv)
 	if err != nil {
 		t.Errorf("Could not insert InvoiceWithValuer using Invoice table: %v", err)
 		t.FailNow()
 	}
 
-	res, err := dbmap.Get(InvoiceWithValuer{}, inv.Id)
+	res, err := dbmap.Get(context.Background(), InvoiceWithValuer{}, inv.Id)
 	if err != nil {
 		t.Errorf("Could not get InvoiceWithValuer: %v", err)
 		t.FailNow()
@@ -1308,14 +1309,14 @@ func TestColumnProps(t *testing.T) {
 
 	// test max size
 	inv.Memo = "this memo is too long"
-	err = dbmap.Insert(inv)
+	err = dbmap.Insert(context.Background(), inv)
 	if err == nil {
 		t.Errorf("max size exceeded, but Insert did not fail.")
 	}
 
 	// test unique - same person id
 	inv = &Invoice{0, 0, 1, "my invoice2", 0, false}
-	err = dbmap.Insert(inv)
+	err = dbmap.Insert(context.Background(), inv)
 	if err == nil {
 		t.Errorf("same PersonId inserted, but Insert did not fail.")
 	}
@@ -1385,7 +1386,7 @@ func TestHooks(t *testing.T) {
 
 	// Test error case
 	p2 := &Person{0, 0, 0, "badname", "", 0}
-	err := dbmap.Insert(p2)
+	err := dbmap.Insert(context.Background(), p2)
 	if err == nil {
 		t.Errorf("p2.PreInsert() didn't return an error")
 	}
@@ -1398,24 +1399,24 @@ func TestTransaction(t *testing.T) {
 	inv1 := &Invoice{0, 100, 200, "t1", 0, true}
 	inv2 := &Invoice{0, 100, 200, "t2", 0, false}
 
-	trans, err := dbmap.Begin()
+	trans, err := dbmap.BeginTx(context.Background())
 	if err != nil {
 		panic(err)
 	}
-	trans.Insert(inv1, inv2)
+	trans.Insert(context.Background(), inv1, inv2)
 	err = trans.Commit()
 	if err != nil {
 		panic(err)
 	}
 
-	obj, err := dbmap.Get(Invoice{}, inv1.Id)
+	obj, err := dbmap.Get(context.Background(), Invoice{}, inv1.Id)
 	if err != nil {
 		panic(err)
 	}
 	if !reflect.DeepEqual(inv1, obj) {
 		t.Errorf("%v != %v", inv1, obj)
 	}
-	obj, err = dbmap.Get(Invoice{}, inv2.Id)
+	obj, err = dbmap.Get(context.Background(), Invoice{}, inv2.Id)
 	if err != nil {
 		panic(err)
 	}
@@ -1427,7 +1428,7 @@ func TestTransaction(t *testing.T) {
 func TestTransactionExecNamed(t *testing.T) {
 	dbmap := initDBMap(t)
 	defer dropAndClose(dbmap)
-	trans, err := dbmap.Begin()
+	trans, err := dbmap.BeginTx(context.Background())
 	if err != nil {
 		panic(err)
 	}
@@ -1441,7 +1442,7 @@ func TestTransactionExecNamed(t *testing.T) {
 		"isPaid":   false,
 	}
 
-	result, err := trans.Exec(`INSERT INTO invoice_test (Created, Updated, Memo, PersonId, IsPaid) Values(:created, :updated, :memo, :personID, :isPaid)`, args)
+	result, err := trans.ExecContext(context.Background(), `INSERT INTO invoice_test (Created, Updated, Memo, PersonId, IsPaid) Values(:created, :updated, :memo, :personID, :isPaid)`, args)
 	if err != nil {
 		panic(err)
 	}
@@ -1453,7 +1454,7 @@ func TestTransactionExecNamed(t *testing.T) {
 		args := map[string]interface{}{
 			"id": id,
 		}
-		memo, err := trans.SelectStr("select memo from invoice_test where id = :id", args)
+		memo, err := trans.SelectStr(context.Background(), "select memo from invoice_test where id = :id", args)
 		if err != nil {
 			panic(err)
 		}
@@ -1464,7 +1465,7 @@ func TestTransactionExecNamed(t *testing.T) {
 	checkMemo("unpaid")
 
 	// exec should still work with ? params
-	result, err = trans.Exec(`INSERT INTO invoice_test (Created, Updated, Memo, PersonId, IsPaid) Values(?, ?, ?, ?, ?)`, 10, 15, "paid", 0, true)
+	result, err = trans.ExecContext(context.Background(), `INSERT INTO invoice_test (Created, Updated, Memo, PersonId, IsPaid) Values(?, ?, ?, ?, ?)`, 10, 15, "paid", 0, true)
 	if err != nil {
 		panic(err)
 	}
@@ -1485,14 +1486,14 @@ func TestSavepoint(t *testing.T) {
 
 	inv1 := &Invoice{0, 100, 200, "unpaid", 0, false}
 
-	trans, err := dbmap.Begin()
+	trans, err := dbmap.BeginTx(context.Background())
 	if err != nil {
 		panic(err)
 	}
-	trans.Insert(inv1)
+	trans.Insert(context.Background(), inv1)
 
 	var checkMemo = func(want string) {
-		memo, err := trans.SelectStr("select " + columnName(dbmap, Invoice{}, "Memo") + " from invoice_test")
+		memo, err := trans.SelectStr(context.Background(), "select "+columnName(dbmap, Invoice{}, "Memo")+" from invoice_test")
 		if err != nil {
 			panic(err)
 		}
@@ -1502,20 +1503,20 @@ func TestSavepoint(t *testing.T) {
 	}
 	checkMemo("unpaid")
 
-	err = trans.Savepoint("foo")
+	err = trans.Savepoint(context.Background(), "foo")
 	if err != nil {
 		panic(err)
 	}
 	checkMemo("unpaid")
 
 	inv1.Memo = "paid"
-	_, err = trans.Update(inv1)
+	_, err = trans.Update(context.Background(), inv1)
 	if err != nil {
 		panic(err)
 	}
 	checkMemo("paid")
 
-	err = trans.RollbackToSavepoint("foo")
+	err = trans.RollbackToSavepoint(context.Background(), "foo")
 	if err != nil {
 		panic(err)
 	}
@@ -1567,7 +1568,7 @@ func testCrudInternal(t *testing.T, dbmap *borp.DbMap, val testable) {
 		t.Errorf("couldn't call TableFor: val=%v err=%v", val, err)
 	}
 
-	_, err = dbmap.Exec("delete from " + table.TableName)
+	_, err = dbmap.ExecContext(context.Background(), "delete from "+table.TableName)
 	if err != nil {
 		t.Errorf("couldn't delete rows from: val=%v err=%v", val, err)
 	}
@@ -1597,7 +1598,7 @@ func testCrudInternal(t *testing.T, dbmap *borp.DbMap, val testable) {
 	}
 
 	// Select *
-	rows, err := dbmap.Select(val, "select * from "+dbmap.Dialect.QuoteField(table.TableName))
+	rows, err := dbmap.Select(context.Background(), val, "select * from "+dbmap.Dialect.QuoteField(table.TableName))
 	if err != nil {
 		t.Errorf("couldn't select * from %s err=%v", dbmap.Dialect.QuoteField(table.TableName), err)
 	} else if len(rows) != 1 {
@@ -1917,14 +1918,14 @@ func TestVersionMultipleRows(t *testing.T) {
 func TestWithStringPk(t *testing.T) {
 	dbmap := newDBMap(t)
 	dbmap.AddTableWithName(WithStringPk{}, "string_pk_test").SetKeys(true, "Id")
-	_, err := dbmap.Exec("create table string_pk_test (Id varchar(255), Name varchar(255));")
+	_, err := dbmap.ExecContext(context.Background(), "create table string_pk_test (Id varchar(255), Name varchar(255));")
 	if err != nil {
 		t.Errorf("couldn't create string_pk_test: %v", err)
 	}
 	defer dropAndClose(dbmap)
 
 	row := &WithStringPk{"1", "foo"}
-	err = dbmap.Insert(row)
+	err = dbmap.Insert(context.Background(), row)
 	if err == nil {
 		t.Errorf("Expected error when inserting into table w/non Int PK and autoincr set true")
 	}
@@ -1959,11 +1960,11 @@ func TestNullTime(t *testing.T) {
 		Time: borp.NullTime{
 			Valid: false,
 		}}
-	err := dbmap.Insert(ent)
+	err := dbmap.Insert(context.Background(), ent)
 	if err != nil {
 		t.Errorf("failed insert on %s", err.Error())
 	}
-	err = dbmap.SelectOne(ent, `select * from nulltime_test where `+columnName(dbmap, WithNullTime{}, "Id")+`=:Id`, map[string]interface{}{
+	err = dbmap.SelectOne(context.Background(), ent, `select * from nulltime_test where `+columnName(dbmap, WithNullTime{}, "Id")+`=:Id`, map[string]interface{}{
 		"Id": ent.Id,
 	})
 	if err != nil {
@@ -1984,11 +1985,11 @@ func TestNullTime(t *testing.T) {
 			Valid: true,
 			Time:  ts,
 		}}
-	err = dbmap.Insert(ent)
+	err = dbmap.Insert(context.Background(), ent)
 	if err != nil {
 		t.Errorf("failed insert on %s", err.Error())
 	}
-	err = dbmap.SelectOne(ent, `select * from nulltime_test where `+columnName(dbmap, WithNullTime{}, "Id")+`=:Id`, map[string]interface{}{
+	err = dbmap.SelectOne(context.Background(), ent, `select * from nulltime_test where `+columnName(dbmap, WithNullTime{}, "Id")+`=:Id`, map[string]interface{}{
 		"Id": ent.Id,
 	})
 	if err != nil {
@@ -2081,7 +2082,7 @@ func TestWithTimeSelect(t *testing.T) {
 	_insert(dbmap, &w1, &w2)
 
 	var caseIds []int64
-	_, err := dbmap.Select(&caseIds, "SELECT "+columnName(dbmap, WithTime{}, "Id")+" FROM time_test WHERE "+columnName(dbmap, WithTime{}, "Time")+" < "+dbmap.Dialect.BindVar(0), halfhourago)
+	_, err := dbmap.Select(context.Background(), &caseIds, "SELECT "+columnName(dbmap, WithTime{}, "Id")+" FROM time_test WHERE "+columnName(dbmap, WithTime{}, "Time")+" < "+dbmap.Dialect.BindVar(0), halfhourago)
 
 	if err != nil {
 		t.Error(err)
@@ -2100,11 +2101,11 @@ func TestInvoicePersonView(t *testing.T) {
 
 	// Create some rows
 	p1 := &Person{0, 0, 0, "bob", "smith", 0}
-	dbmap.Insert(p1)
+	dbmap.Insert(context.Background(), p1)
 
 	// notice how we can wire up p1.Id to the invoice easily
 	inv1 := &Invoice{0, 0, 0, "xmas order", p1.Id, false}
-	dbmap.Insert(inv1)
+	dbmap.Insert(context.Background(), inv1)
 
 	// Run your query
 	query := "select i." + columnName(dbmap, Invoice{}, "Id") + " InvoiceId, p." + columnName(dbmap, Person{}, "Id") + " PersonId, i." + columnName(dbmap, Invoice{}, "Memo") + ", p." + columnName(dbmap, Person{}, "FName") + " " +
@@ -2114,7 +2115,7 @@ func TestInvoicePersonView(t *testing.T) {
 	// pass a slice of pointers to Select()
 	// this avoids the need to type assert after the query is run
 	var list []*InvoicePersonView
-	_, err := dbmap.Select(&list, query)
+	_, err := dbmap.Select(context.Background(), &list, query)
 	if err != nil {
 		panic(err)
 	}
@@ -2141,14 +2142,14 @@ func TestQuoteTableNames(t *testing.T) {
 	errorTemplate := "Expected quoted table name %v in query but didn't find it"
 
 	// Check if Insert quotes the table name
-	id := dbmap.Insert(p1)
+	id := dbmap.Insert(context.Background(), p1)
 	if !bytes.Contains(logBuffer.Bytes(), []byte(quotedTableName)) {
 		t.Errorf(errorTemplate, quotedTableName)
 	}
 	logBuffer.Reset()
 
 	// Check if Get quotes the table name
-	dbmap.Get(Person{}, id)
+	dbmap.Get(context.Background(), Person{}, id)
 	if !bytes.Contains(logBuffer.Bytes(), []byte(quotedTableName)) {
 		t.Errorf(errorTemplate, quotedTableName)
 	}
@@ -2174,7 +2175,7 @@ func TestSelectTooManyCols(t *testing.T) {
 	}
 
 	var p3 FNameOnly
-	err := dbmap.SelectOne(&p3, "select * from person_test where "+columnName(dbmap, Person{}, "Id")+"=:Id", params)
+	err := dbmap.SelectOne(context.Background(), &p3, "select * from person_test where "+columnName(dbmap, Person{}, "Id")+"=:Id", params)
 	if err != nil {
 		if !borp.NonFatalError(err) {
 			t.Error(err)
@@ -2188,7 +2189,7 @@ func TestSelectTooManyCols(t *testing.T) {
 	}
 
 	var pSlice []FNameOnly
-	_, err = dbmap.Select(&pSlice, "select * from person_test order by "+columnName(dbmap, Person{}, "FName")+" asc")
+	_, err = dbmap.Select(context.Background(), &pSlice, "select * from person_test order by "+columnName(dbmap, Person{}, "FName")+" asc")
 	if err != nil {
 		if !borp.NonFatalError(err) {
 			t.Error(err)
@@ -2220,7 +2221,7 @@ func TestSelectSingleVal(t *testing.T) {
 	}
 
 	var p2 Person
-	err := dbmap.SelectOne(&p2, "select * from person_test where "+columnName(dbmap, Person{}, "Id")+"=:Id", params)
+	err := dbmap.SelectOne(context.Background(), &p2, "select * from person_test where "+columnName(dbmap, Person{}, "Id")+"=:Id", params)
 	if err != nil {
 		t.Error(err)
 	}
@@ -2231,7 +2232,7 @@ func TestSelectSingleVal(t *testing.T) {
 
 	// verify SelectOne allows non-struct holders
 	var s string
-	err = dbmap.SelectOne(&s, "select "+columnName(dbmap, Person{}, "FName")+" from person_test where "+columnName(dbmap, Person{}, "Id")+"=:Id", params)
+	err = dbmap.SelectOne(context.Background(), &s, "select "+columnName(dbmap, Person{}, "FName")+" from person_test where "+columnName(dbmap, Person{}, "Id")+"=:Id", params)
 	if err != nil {
 		t.Error(err)
 	}
@@ -2240,14 +2241,14 @@ func TestSelectSingleVal(t *testing.T) {
 	}
 
 	// verify SelectOne requires pointer receiver
-	err = dbmap.SelectOne(s, "select "+columnName(dbmap, Person{}, "FName")+" from person_test where "+columnName(dbmap, Person{}, "Id")+"=:Id", params)
+	err = dbmap.SelectOne(context.Background(), s, "select "+columnName(dbmap, Person{}, "FName")+" from person_test where "+columnName(dbmap, Person{}, "Id")+"=:Id", params)
 	if err == nil {
 		t.Error("SelectOne should have returned error for non-pointer holder")
 	}
 
 	// verify SelectOne works with uninitialized pointers
 	var p3 *Person
-	err = dbmap.SelectOne(&p3, "select * from person_test where "+columnName(dbmap, Person{}, "Id")+"=:Id", params)
+	err = dbmap.SelectOne(context.Background(), &p3, "select * from person_test where "+columnName(dbmap, Person{}, "Id")+"=:Id", params)
 	if err != nil {
 		t.Error(err)
 	}
@@ -2258,13 +2259,13 @@ func TestSelectSingleVal(t *testing.T) {
 
 	// verify that the receiver is still nil if nothing was found
 	var p4 *Person
-	dbmap.SelectOne(&p3, "select * from person_test where 2<1 AND "+columnName(dbmap, Person{}, "Id")+"=:Id", params)
+	dbmap.SelectOne(context.Background(), &p3, "select * from person_test where 2<1 AND "+columnName(dbmap, Person{}, "Id")+"=:Id", params)
 	if p4 != nil {
 		t.Error("SelectOne should not have changed a nil receiver when no rows were found")
 	}
 
 	// verify that the error is set to sql.ErrNoRows if not found
-	err = dbmap.SelectOne(&p2, "select * from person_test where "+columnName(dbmap, Person{}, "Id")+"=:Id", map[string]interface{}{
+	err = dbmap.SelectOne(context.Background(), &p2, "select * from person_test where "+columnName(dbmap, Person{}, "Id")+"=:Id", map[string]interface{}{
 		"Id": -2222,
 	})
 	if err == nil || err != sql.ErrNoRows {
@@ -2272,7 +2273,7 @@ func TestSelectSingleVal(t *testing.T) {
 	}
 
 	_insert(dbmap, &Person{0, 0, 0, "bob", "smith", 0})
-	err = dbmap.SelectOne(&p2, "select * from person_test where "+columnName(dbmap, Person{}, "FName")+"='bob'")
+	err = dbmap.SelectOne(context.Background(), &p2, "select * from person_test where "+columnName(dbmap, Person{}, "FName")+"='bob'")
 	if err == nil {
 		t.Error("Expected error when two rows found")
 	}
@@ -2284,7 +2285,7 @@ func TestSelectSingleVal(t *testing.T) {
 	var tFloat float64
 	primVals := []interface{}{tInt, tStr, tBool, tFloat}
 	for _, prim := range primVals {
-		err = dbmap.SelectOne(&prim, "select * from person_test where "+columnName(dbmap, Person{}, "Id")+"=-123")
+		err = dbmap.SelectOne(context.Background(), &prim, "select * from person_test where "+columnName(dbmap, Person{}, "Id")+"=-123")
 		if err == nil || err != sql.ErrNoRows {
 			t.Error("primVals: SelectOne should have returned sql.ErrNoRows")
 		}
@@ -2303,7 +2304,7 @@ func TestSelectAlias(t *testing.T) {
 	// Select into IdCreatedExternal type, which includes some fields not present
 	// in id_created_test
 	var p2 IdCreatedExternal
-	err := dbmap.SelectOne(&p2, "select * from id_created_test where "+columnName(dbmap, IdCreatedExternal{}, "Id")+"=1")
+	err := dbmap.SelectOne(context.Background(), &p2, "select * from id_created_test where "+columnName(dbmap, IdCreatedExternal{}, "Id")+"=1")
 	if err != nil {
 		t.Error(err)
 	}
@@ -2313,7 +2314,7 @@ func TestSelectAlias(t *testing.T) {
 
 	// Prove that we can supply an aliased value in the select, and that it will
 	// automatically map to IdCreatedExternal.External
-	err = dbmap.SelectOne(&p2, "SELECT *, 1 AS external FROM id_created_test")
+	err = dbmap.SelectOne(context.Background(), &p2, "SELECT *, 1 AS external FROM id_created_test")
 	if err != nil {
 		t.Error(err)
 	}
@@ -2375,7 +2376,7 @@ func TestSingleColumnKeyDbReturnsZeroRowsUpdatedOnPKChange(t *testing.T) {
 		SomeId: "A Unique Id String",
 	}
 
-	count, err := dbmap.Update(&sct)
+	count, err := dbmap.Update(context.Background(), &sct)
 	if err != nil {
 		t.Error(err)
 	}
@@ -2385,7 +2386,7 @@ func TestSingleColumnKeyDbReturnsZeroRowsUpdatedOnPKChange(t *testing.T) {
 
 }
 
-func TestPrepare(t *testing.T) {
+func TestPrepareContext(t *testing.T) {
 	dbmap := initDBMap(t)
 	defer dropAndClose(dbmap)
 
@@ -2395,38 +2396,38 @@ func TestPrepare(t *testing.T) {
 
 	bindVar0 := dbmap.Dialect.BindVar(0)
 	bindVar1 := dbmap.Dialect.BindVar(1)
-	stmt, err := dbmap.Prepare(fmt.Sprintf("UPDATE invoice_test SET "+columnName(dbmap, Invoice{}, "Memo")+"=%s WHERE "+columnName(dbmap, Invoice{}, "Id")+"=%s", bindVar0, bindVar1))
+	stmt, err := dbmap.PrepareContext(context.Background(), fmt.Sprintf("UPDATE invoice_test SET "+columnName(dbmap, Invoice{}, "Memo")+"=%s WHERE "+columnName(dbmap, Invoice{}, "Id")+"=%s", bindVar0, bindVar1))
 	if err != nil {
 		t.Error(err)
 	}
 	defer stmt.Close()
-	_, err = stmt.Exec("prepare-baz", inv1.Id)
+	_, err = stmt.ExecContext(context.Background(), "prepare-baz", inv1.Id)
 	if err != nil {
 		t.Error(err)
 	}
-	err = dbmap.SelectOne(inv1, "SELECT * from invoice_test WHERE "+columnName(dbmap, Invoice{}, "Memo")+"='prepare-baz'")
+	err = dbmap.SelectOne(context.Background(), inv1, "SELECT * from invoice_test WHERE "+columnName(dbmap, Invoice{}, "Memo")+"='prepare-baz'")
 	if err != nil {
 		t.Error(err)
 	}
 
-	trans, err := dbmap.Begin()
+	trans, err := dbmap.BeginTx(context.Background())
 	if err != nil {
 		t.Error(err)
 	}
-	transStmt, err := trans.Prepare(fmt.Sprintf("UPDATE invoice_test SET "+columnName(dbmap, Invoice{}, "IsPaid")+"=%s WHERE "+columnName(dbmap, Invoice{}, "Id")+"=%s", bindVar0, bindVar1))
+	transStmt, err := trans.PrepareContext(context.Background(), fmt.Sprintf("UPDATE invoice_test SET "+columnName(dbmap, Invoice{}, "IsPaid")+"=%s WHERE "+columnName(dbmap, Invoice{}, "Id")+"=%s", bindVar0, bindVar1))
 	if err != nil {
 		t.Error(err)
 	}
 	defer transStmt.Close()
-	_, err = transStmt.Exec(true, inv2.Id)
+	_, err = transStmt.ExecContext(context.Background(), true, inv2.Id)
 	if err != nil {
 		t.Error(err)
 	}
-	err = dbmap.SelectOne(inv2, fmt.Sprintf("SELECT * from invoice_test WHERE "+columnName(dbmap, Invoice{}, "IsPaid")+"=%s", bindVar0), true)
+	err = dbmap.SelectOne(context.Background(), inv2, fmt.Sprintf("SELECT * from invoice_test WHERE "+columnName(dbmap, Invoice{}, "IsPaid")+"=%s", bindVar0), true)
 	if err == nil || err != sql.ErrNoRows {
 		t.Error("SelectOne should have returned an sql.ErrNoRows")
 	}
-	err = trans.SelectOne(inv2, fmt.Sprintf("SELECT * from invoice_test WHERE "+columnName(dbmap, Invoice{}, "IsPaid")+"=%s", bindVar0), true)
+	err = trans.SelectOne(context.Background(), inv2, fmt.Sprintf("SELECT * from invoice_test WHERE "+columnName(dbmap, Invoice{}, "IsPaid")+"=%s", bindVar0), true)
 	if err != nil {
 		t.Error(err)
 	}
@@ -2434,7 +2435,7 @@ func TestPrepare(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	err = dbmap.SelectOne(inv2, fmt.Sprintf("SELECT * from invoice_test WHERE "+columnName(dbmap, Invoice{}, "IsPaid")+"=%s", bindVar0), true)
+	err = dbmap.SelectOne(context.Background(), inv2, fmt.Sprintf("SELECT * from invoice_test WHERE "+columnName(dbmap, Invoice{}, "IsPaid")+"=%s", bindVar0), true)
 	if err != nil {
 		t.Error(err)
 	}
@@ -2487,7 +2488,7 @@ func BenchmarkNativeCrud(b *testing.B) {
 	inv := &Invoice{0, 100, 200, "my memo", 0, false}
 
 	for i := 0; i < b.N; i++ {
-		res, err := dbmap.Db.Exec(insert, inv.Created, inv.Updated,
+		res, err := dbmap.Db.ExecContext(context.Background(), insert, inv.Created, inv.Updated,
 			inv.Memo, inv.PersonId)
 		if err != nil {
 			panic(err)
@@ -2511,13 +2512,13 @@ func BenchmarkNativeCrud(b *testing.B) {
 		inv.Memo = "my memo 2"
 		inv.PersonId = 3000
 
-		_, err = dbmap.Db.Exec(update, inv.Created, inv.Updated, inv.Memo,
+		_, err = dbmap.Db.ExecContext(context.Background(), update, inv.Created, inv.Updated, inv.Memo,
 			inv.PersonId, inv.Id)
 		if err != nil {
 			panic(err)
 		}
 
-		_, err = dbmap.Db.Exec(delete, inv.Id)
+		_, err = dbmap.Db.ExecContext(context.Background(), delete, inv.Id)
 		if err != nil {
 			panic(err)
 		}
@@ -2533,12 +2534,12 @@ func BenchmarkGorpCrud(b *testing.B) {
 
 	inv := &Invoice{0, 100, 200, "my memo", 0, true}
 	for i := 0; i < b.N; i++ {
-		err := dbmap.Insert(inv)
+		err := dbmap.Insert(context.Background(), inv)
 		if err != nil {
 			panic(err)
 		}
 
-		obj, err := dbmap.Get(Invoice{}, inv.Id)
+		obj, err := dbmap.Get(context.Background(), Invoice{}, inv.Id)
 		if err != nil {
 			panic(err)
 		}
@@ -2552,12 +2553,12 @@ func BenchmarkGorpCrud(b *testing.B) {
 		inv2.Updated = 2000
 		inv2.Memo = "my memo 2"
 		inv2.PersonId = 3000
-		_, err = dbmap.Update(inv2)
+		_, err = dbmap.Update(context.Background(), inv2)
 		if err != nil {
 			panic(err)
 		}
 
-		_, err = dbmap.Delete(inv2)
+		_, err = dbmap.Delete(context.Background(), inv2)
 		if err != nil {
 			panic(err)
 		}
@@ -2567,7 +2568,7 @@ func BenchmarkGorpCrud(b *testing.B) {
 
 func initDBMapBench(b *testing.B) *borp.DbMap {
 	dbmap := newDBMap(b)
-	dbmap.Db.Exec("drop table if exists invoice_test")
+	dbmap.Db.ExecContext(context.Background(), "drop table if exists invoice_test")
 	dbmap.AddTableWithName(Invoice{}, "invoice_test").SetKeys(true, "Id")
 	err := dbmap.CreateTables()
 	if err != nil {
@@ -2680,14 +2681,14 @@ func dialectAndDriver() (borp.Dialect, string) {
 }
 
 func _insert(dbmap *borp.DbMap, list ...interface{}) {
-	err := dbmap.Insert(list...)
+	err := dbmap.Insert(context.Background(), list...)
 	if err != nil {
 		panic(err)
 	}
 }
 
 func _update(dbmap *borp.DbMap, list ...interface{}) int64 {
-	count, err := dbmap.Update(list...)
+	count, err := dbmap.Update(context.Background(), list...)
 	if err != nil {
 		panic(err)
 	}
@@ -2695,7 +2696,7 @@ func _update(dbmap *borp.DbMap, list ...interface{}) int64 {
 }
 
 func _updateColumns(dbmap *borp.DbMap, filter borp.ColumnFilter, list ...interface{}) int64 {
-	count, err := dbmap.UpdateColumns(filter, list...)
+	count, err := dbmap.UpdateColumns(context.Background(), filter, list...)
 	if err != nil {
 		panic(err)
 	}
@@ -2703,7 +2704,7 @@ func _updateColumns(dbmap *borp.DbMap, filter borp.ColumnFilter, list ...interfa
 }
 
 func _del(dbmap *borp.DbMap, list ...interface{}) int64 {
-	count, err := dbmap.Delete(list...)
+	count, err := dbmap.Delete(context.Background(), list...)
 	if err != nil {
 		panic(err)
 	}
@@ -2712,7 +2713,7 @@ func _del(dbmap *borp.DbMap, list ...interface{}) int64 {
 }
 
 func _get(dbmap *borp.DbMap, i interface{}, keys ...interface{}) interface{} {
-	obj, err := dbmap.Get(i, keys...)
+	obj, err := dbmap.Get(context.Background(), i, keys...)
 	if err != nil {
 		panic(err)
 	}
@@ -2721,7 +2722,7 @@ func _get(dbmap *borp.DbMap, i interface{}, keys ...interface{}) interface{} {
 }
 
 func selectInt(dbmap *borp.DbMap, query string, args ...interface{}) int64 {
-	i64, err := borp.SelectInt(dbmap, query, args...)
+	i64, err := borp.SelectInt(context.Background(), dbmap, query, args...)
 	if err != nil {
 		panic(err)
 	}
@@ -2730,7 +2731,7 @@ func selectInt(dbmap *borp.DbMap, query string, args ...interface{}) int64 {
 }
 
 func selectNullInt(dbmap *borp.DbMap, query string, args ...interface{}) sql.NullInt64 {
-	i64, err := borp.SelectNullInt(dbmap, query, args...)
+	i64, err := borp.SelectNullInt(context.Background(), dbmap, query, args...)
 	if err != nil {
 		panic(err)
 	}
@@ -2739,7 +2740,7 @@ func selectNullInt(dbmap *borp.DbMap, query string, args ...interface{}) sql.Nul
 }
 
 func selectFloat(dbmap *borp.DbMap, query string, args ...interface{}) float64 {
-	f64, err := borp.SelectFloat(dbmap, query, args...)
+	f64, err := borp.SelectFloat(context.Background(), dbmap, query, args...)
 	if err != nil {
 		panic(err)
 	}
@@ -2748,7 +2749,7 @@ func selectFloat(dbmap *borp.DbMap, query string, args ...interface{}) float64 {
 }
 
 func selectNullFloat(dbmap *borp.DbMap, query string, args ...interface{}) sql.NullFloat64 {
-	f64, err := borp.SelectNullFloat(dbmap, query, args...)
+	f64, err := borp.SelectNullFloat(context.Background(), dbmap, query, args...)
 	if err != nil {
 		panic(err)
 	}
@@ -2757,7 +2758,7 @@ func selectNullFloat(dbmap *borp.DbMap, query string, args ...interface{}) sql.N
 }
 
 func selectStr(dbmap *borp.DbMap, query string, args ...interface{}) string {
-	s, err := borp.SelectStr(dbmap, query, args...)
+	s, err := borp.SelectStr(context.Background(), dbmap, query, args...)
 	if err != nil {
 		panic(err)
 	}
@@ -2766,7 +2767,7 @@ func selectStr(dbmap *borp.DbMap, query string, args ...interface{}) string {
 }
 
 func selectNullStr(dbmap *borp.DbMap, query string, args ...interface{}) sql.NullString {
-	s, err := borp.SelectNullStr(dbmap, query, args...)
+	s, err := borp.SelectNullStr(context.Background(), dbmap, query, args...)
 	if err != nil {
 		panic(err)
 	}
@@ -2775,7 +2776,7 @@ func selectNullStr(dbmap *borp.DbMap, query string, args ...interface{}) sql.Nul
 }
 
 func rawExec(dbmap *borp.DbMap, query string, args ...interface{}) sql.Result {
-	res, err := dbmap.Exec(query, args...)
+	res, err := dbmap.ExecContext(context.Background(), query, args...)
 	if err != nil {
 		panic(err)
 	}
@@ -2783,7 +2784,7 @@ func rawExec(dbmap *borp.DbMap, query string, args ...interface{}) sql.Result {
 }
 
 func rawSelect(dbmap *borp.DbMap, i interface{}, query string, args ...interface{}) []interface{} {
-	list, err := dbmap.Select(i, query, args...)
+	list, err := dbmap.Select(context.Background(), i, query, args...)
 	if err != nil {
 		panic(err)
 	}

--- a/lockerror.go
+++ b/lockerror.go
@@ -5,6 +5,7 @@
 package borp
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 )
@@ -39,11 +40,11 @@ func (e OptimisticLockError) Error() string {
 	return fmt.Sprintf("gorp: OptimisticLockError no row found for table=%s keys=%v", e.TableName, e.Keys)
 }
 
-func lockError(m *DbMap, exec SqlExecutor, tableName string,
+func lockError(ctx context.Context, m *DbMap, exec SqlExecutor, tableName string,
 	existingVer int64, elem reflect.Value,
 	keys ...interface{}) (int64, error) {
 
-	existing, err := get(m, exec, elem.Interface(), keys...)
+	existing, err := get(ctx, m, exec, elem.Interface(), keys...)
 	if err != nil {
 		return -1, err
 	}

--- a/select.go
+++ b/select.go
@@ -87,7 +87,7 @@ func SelectNullStr(ctx context.Context, e SqlExecutor, query string, args ...int
 // SelectOne executes the given query (which should be a SELECT statement)
 // and binds the result to holder, which must be a pointer.
 //
-// # If no row is found, an error (sql.ErrNoRows specifically) will be returned
+// If no row is found, an error (sql.ErrNoRows specifically) will be returned.
 //
 // If more than one row is found, an error will be returned.
 func SelectOne(ctx context.Context, m *DbMap, e SqlExecutor, holder interface{}, query string, args ...interface{}) error {

--- a/select.go
+++ b/select.go
@@ -5,6 +5,7 @@
 package borp
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"reflect"
@@ -13,9 +14,9 @@ import (
 // SelectInt executes the given query, which should be a SELECT statement for a single
 // integer column, and returns the value of the first row returned.  If no rows are
 // found, zero is returned.
-func SelectInt(e SqlExecutor, query string, args ...interface{}) (int64, error) {
+func SelectInt(ctx context.Context, e SqlExecutor, query string, args ...interface{}) (int64, error) {
 	var h int64
-	err := selectVal(e, &h, query, args...)
+	err := selectVal(ctx, e, &h, query, args...)
 	if err != nil && err != sql.ErrNoRows {
 		return 0, err
 	}
@@ -25,9 +26,9 @@ func SelectInt(e SqlExecutor, query string, args ...interface{}) (int64, error) 
 // SelectNullInt executes the given query, which should be a SELECT statement for a single
 // integer column, and returns the value of the first row returned.  If no rows are
 // found, the empty sql.NullInt64 value is returned.
-func SelectNullInt(e SqlExecutor, query string, args ...interface{}) (sql.NullInt64, error) {
+func SelectNullInt(ctx context.Context, e SqlExecutor, query string, args ...interface{}) (sql.NullInt64, error) {
 	var h sql.NullInt64
-	err := selectVal(e, &h, query, args...)
+	err := selectVal(ctx, e, &h, query, args...)
 	if err != nil && err != sql.ErrNoRows {
 		return h, err
 	}
@@ -37,9 +38,9 @@ func SelectNullInt(e SqlExecutor, query string, args ...interface{}) (sql.NullIn
 // SelectFloat executes the given query, which should be a SELECT statement for a single
 // float column, and returns the value of the first row returned. If no rows are
 // found, zero is returned.
-func SelectFloat(e SqlExecutor, query string, args ...interface{}) (float64, error) {
+func SelectFloat(ctx context.Context, e SqlExecutor, query string, args ...interface{}) (float64, error) {
 	var h float64
-	err := selectVal(e, &h, query, args...)
+	err := selectVal(ctx, e, &h, query, args...)
 	if err != nil && err != sql.ErrNoRows {
 		return 0, err
 	}
@@ -49,9 +50,9 @@ func SelectFloat(e SqlExecutor, query string, args ...interface{}) (float64, err
 // SelectNullFloat executes the given query, which should be a SELECT statement for a single
 // float column, and returns the value of the first row returned. If no rows are
 // found, the empty sql.NullInt64 value is returned.
-func SelectNullFloat(e SqlExecutor, query string, args ...interface{}) (sql.NullFloat64, error) {
+func SelectNullFloat(ctx context.Context, e SqlExecutor, query string, args ...interface{}) (sql.NullFloat64, error) {
 	var h sql.NullFloat64
-	err := selectVal(e, &h, query, args...)
+	err := selectVal(ctx, e, &h, query, args...)
 	if err != nil && err != sql.ErrNoRows {
 		return h, err
 	}
@@ -61,9 +62,9 @@ func SelectNullFloat(e SqlExecutor, query string, args ...interface{}) (sql.Null
 // SelectStr executes the given query, which should be a SELECT statement for a single
 // char/varchar column, and returns the value of the first row returned.  If no rows are
 // found, an empty string is returned.
-func SelectStr(e SqlExecutor, query string, args ...interface{}) (string, error) {
+func SelectStr(ctx context.Context, e SqlExecutor, query string, args ...interface{}) (string, error) {
 	var h string
-	err := selectVal(e, &h, query, args...)
+	err := selectVal(ctx, e, &h, query, args...)
 	if err != nil && err != sql.ErrNoRows {
 		return "", err
 	}
@@ -74,9 +75,9 @@ func SelectStr(e SqlExecutor, query string, args ...interface{}) (string, error)
 // statement for a single char/varchar column, and returns the value
 // of the first row returned.  If no rows are found, the empty
 // sql.NullString is returned.
-func SelectNullStr(e SqlExecutor, query string, args ...interface{}) (sql.NullString, error) {
+func SelectNullStr(ctx context.Context, e SqlExecutor, query string, args ...interface{}) (sql.NullString, error) {
 	var h sql.NullString
-	err := selectVal(e, &h, query, args...)
+	err := selectVal(ctx, e, &h, query, args...)
 	if err != nil && err != sql.ErrNoRows {
 		return h, err
 	}
@@ -86,11 +87,10 @@ func SelectNullStr(e SqlExecutor, query string, args ...interface{}) (sql.NullSt
 // SelectOne executes the given query (which should be a SELECT statement)
 // and binds the result to holder, which must be a pointer.
 //
-// If no row is found, an error (sql.ErrNoRows specifically) will be returned
+// # If no row is found, an error (sql.ErrNoRows specifically) will be returned
 //
 // If more than one row is found, an error will be returned.
-//
-func SelectOne(m *DbMap, e SqlExecutor, holder interface{}, query string, args ...interface{}) error {
+func SelectOne(ctx context.Context, m *DbMap, e SqlExecutor, holder interface{}, query string, args ...interface{}) error {
 	t := reflect.TypeOf(holder)
 	if t.Kind() == reflect.Ptr {
 		t = t.Elem()
@@ -108,7 +108,7 @@ func SelectOne(m *DbMap, e SqlExecutor, holder interface{}, query string, args .
 	if t.Kind() == reflect.Struct {
 		var nonFatalErr error
 
-		list, err := hookedselect(m, e, holder, query, args...)
+		list, err := hookedselect(ctx, m, e, holder, query, args...)
 		if err != nil {
 			if !NonFatalError(err) { // FIXME: double negative, rename NonFatalError to FatalError
 				return err
@@ -143,10 +143,10 @@ func SelectOne(m *DbMap, e SqlExecutor, holder interface{}, query string, args .
 		return nonFatalErr
 	}
 
-	return selectVal(e, holder, query, args...)
+	return selectVal(ctx, e, holder, query, args...)
 }
 
-func selectVal(e SqlExecutor, holder interface{}, query string, args ...interface{}) error {
+func selectVal(ctx context.Context, e SqlExecutor, holder interface{}, query string, args ...interface{}) error {
 	if len(args) == 1 {
 		switch m := e.(type) {
 		case *DbMap:
@@ -155,7 +155,7 @@ func selectVal(e SqlExecutor, holder interface{}, query string, args ...interfac
 			query, args = maybeExpandNamedQuery(m.dbmap, query, args)
 		}
 	}
-	rows, err := e.Query(query, args...)
+	rows, err := e.QueryContext(ctx, query, args...)
 	if err != nil {
 		return err
 	}
@@ -176,12 +176,12 @@ func selectVal(e SqlExecutor, holder interface{}, query string, args ...interfac
 	return rows.Close()
 }
 
-func hookedselect(m *DbMap, exec SqlExecutor, i interface{}, query string,
+func hookedselect(ctx context.Context, m *DbMap, exec SqlExecutor, i interface{}, query string,
 	args ...interface{}) ([]interface{}, error) {
 
 	var nonFatalErr error
 
-	list, err := rawselect(m, exec, i, query, args...)
+	list, err := rawselect(ctx, m, exec, i, query, args...)
 	if err != nil {
 		if !NonFatalError(err) {
 			return nil, err
@@ -213,7 +213,7 @@ func hookedselect(m *DbMap, exec SqlExecutor, i interface{}, query string,
 	return list, nonFatalErr
 }
 
-func rawselect(m *DbMap, exec SqlExecutor, i interface{}, query string,
+func rawselect(ctx context.Context, m *DbMap, exec SqlExecutor, i interface{}, query string,
 	args ...interface{}) ([]interface{}, error) {
 	var (
 		appendToSlice   = false // Write results to i directly?
@@ -256,7 +256,7 @@ func rawselect(m *DbMap, exec SqlExecutor, i interface{}, query string,
 	}
 
 	// Run the query
-	rows, err := exec.Query(query, args...)
+	rows, err := exec.QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, err
 	}

--- a/transaction.go
+++ b/transaction.go
@@ -203,7 +203,7 @@ func (t *Transaction) PrepareContext(ctx context.Context, query string) (*sql.St
 		now := time.Now()
 		defer t.dbmap.trace(now, query, nil)
 	}
-	return t.PrepareContext(ctx, query)
+	return t.tx.PrepareContext(ctx, query)
 }
 
 func (t *Transaction) QueryRowContext(ctx context.Context, query string, args ...interface{}) *sql.Row {
@@ -215,7 +215,7 @@ func (t *Transaction) QueryRowContext(ctx context.Context, query string, args ..
 		now := time.Now()
 		defer t.dbmap.trace(now, query, args...)
 	}
-	return t.QueryRowContext(ctx, query, args...)
+	return t.tx.QueryRowContext(ctx, query, args...)
 }
 
 func (t *Transaction) QueryContext(ctx context.Context, q string, args ...interface{}) (*sql.Rows, error) {
@@ -227,5 +227,5 @@ func (t *Transaction) QueryContext(ctx context.Context, q string, args ...interf
 		now := time.Now()
 		defer t.dbmap.trace(now, q, args...)
 	}
-	return t.QueryContext(ctx, q, args...)
+	return t.tx.QueryContext(ctx, q, args...)
 }

--- a/transaction.go
+++ b/transaction.go
@@ -167,7 +167,7 @@ func (t *Transaction) Savepoint(ctx context.Context, name string) error {
 		now := time.Now()
 		defer t.dbmap.trace(now, query, nil)
 	}
-	_, err := exec(ctx, t, query)
+	_, err := t.ExecContext(ctx, query)
 	return err
 }
 
@@ -180,7 +180,7 @@ func (t *Transaction) RollbackToSavepoint(ctx context.Context, savepoint string)
 		now := time.Now()
 		defer t.dbmap.trace(now, query, nil)
 	}
-	_, err := exec(ctx, t, query)
+	_, err := t.ExecContext(ctx, query)
 	return err
 }
 
@@ -193,7 +193,7 @@ func (t *Transaction) ReleaseSavepoint(ctx context.Context, savepoint string) er
 		now := time.Now()
 		defer t.dbmap.trace(now, query, nil)
 	}
-	_, err := exec(ctx, t, query)
+	_, err := t.ExecContext(ctx, query)
 	return err
 }
 
@@ -203,7 +203,7 @@ func (t *Transaction) PrepareContext(ctx context.Context, query string) (*sql.St
 		now := time.Now()
 		defer t.dbmap.trace(now, query, nil)
 	}
-	return prepare(ctx, t, query)
+	return t.PrepareContext(ctx, query)
 }
 
 func (t *Transaction) QueryRowContext(ctx context.Context, query string, args ...interface{}) *sql.Row {
@@ -215,7 +215,7 @@ func (t *Transaction) QueryRowContext(ctx context.Context, query string, args ..
 		now := time.Now()
 		defer t.dbmap.trace(now, query, args...)
 	}
-	return queryRow(ctx, t, query, args...)
+	return t.QueryRowContext(ctx, query, args...)
 }
 
 func (t *Transaction) QueryContext(ctx context.Context, q string, args ...interface{}) (*sql.Rows, error) {
@@ -227,5 +227,5 @@ func (t *Transaction) QueryContext(ctx context.Context, q string, args ...interf
 		now := time.Now()
 		defer t.dbmap.trace(now, q, args...)
 	}
-	return query(ctx, t, q, args...)
+	return t.QueryContext(ctx, q, args...)
 }

--- a/transaction.go
+++ b/transaction.go
@@ -15,55 +15,47 @@ import (
 // of that transaction.  Transactions should be terminated with
 // a call to Commit() or Rollback()
 type Transaction struct {
-	ctx    context.Context
 	dbmap  *DbMap
 	tx     *sql.Tx
 	closed bool
 }
 
-func (t *Transaction) WithContext(ctx context.Context) SqlExecutor {
-	copy := &Transaction{}
-	*copy = *t
-	copy.ctx = ctx
-	return copy
-}
-
 // Insert has the same behavior as DbMap.Insert(), but runs in a transaction.
-func (t *Transaction) Insert(list ...interface{}) error {
-	return insert(t.dbmap, t, list...)
+func (t *Transaction) Insert(ctx context.Context, list ...interface{}) error {
+	return insert(ctx, t.dbmap, t, list...)
 }
 
 // Update had the same behavior as DbMap.Update(), but runs in a transaction.
-func (t *Transaction) Update(list ...interface{}) (int64, error) {
-	return update(t.dbmap, t, nil, list...)
+func (t *Transaction) Update(ctx context.Context, list ...interface{}) (int64, error) {
+	return update(ctx, t.dbmap, t, nil, list...)
 }
 
 // UpdateColumns had the same behavior as DbMap.UpdateColumns(), but runs in a transaction.
-func (t *Transaction) UpdateColumns(filter ColumnFilter, list ...interface{}) (int64, error) {
-	return update(t.dbmap, t, filter, list...)
+func (t *Transaction) UpdateColumns(ctx context.Context, filter ColumnFilter, list ...interface{}) (int64, error) {
+	return update(ctx, t.dbmap, t, filter, list...)
 }
 
 // Delete has the same behavior as DbMap.Delete(), but runs in a transaction.
-func (t *Transaction) Delete(list ...interface{}) (int64, error) {
-	return delete(t.dbmap, t, list...)
+func (t *Transaction) Delete(ctx context.Context, list ...interface{}) (int64, error) {
+	return delete(ctx, t.dbmap, t, list...)
 }
 
 // Get has the same behavior as DbMap.Get(), but runs in a transaction.
-func (t *Transaction) Get(i interface{}, keys ...interface{}) (interface{}, error) {
-	return get(t.dbmap, t, i, keys...)
+func (t *Transaction) Get(ctx context.Context, i interface{}, keys ...interface{}) (interface{}, error) {
+	return get(ctx, t.dbmap, t, i, keys...)
 }
 
 // Select has the same behavior as DbMap.Select(), but runs in a transaction.
-func (t *Transaction) Select(i interface{}, query string, args ...interface{}) ([]interface{}, error) {
+func (t *Transaction) Select(ctx context.Context, i interface{}, query string, args ...interface{}) ([]interface{}, error) {
 	if t.dbmap.ExpandSliceArgs {
 		expandSliceArgs(&query, args...)
 	}
 
-	return hookedselect(t.dbmap, t, i, query, args...)
+	return hookedselect(ctx, t.dbmap, t, i, query, args...)
 }
 
-// Exec has the same behavior as DbMap.Exec(), but runs in a transaction.
-func (t *Transaction) Exec(query string, args ...interface{}) (sql.Result, error) {
+// ExecContext has the same behavior as DbMap.ExecContext(), but runs in a transaction.
+func (t *Transaction) ExecContext(ctx context.Context, query string, args ...interface{}) (sql.Result, error) {
 	if t.dbmap.ExpandSliceArgs {
 		expandSliceArgs(&query, args...)
 	}
@@ -72,70 +64,70 @@ func (t *Transaction) Exec(query string, args ...interface{}) (sql.Result, error
 		now := time.Now()
 		defer t.dbmap.trace(now, query, args...)
 	}
-	return maybeExpandNamedQueryAndExec(t, query, args...)
+	return maybeExpandNamedQueryAndExec(ctx, t, query, args...)
 }
 
 // SelectInt is a convenience wrapper around the borp.SelectInt function.
-func (t *Transaction) SelectInt(query string, args ...interface{}) (int64, error) {
+func (t *Transaction) SelectInt(ctx context.Context, query string, args ...interface{}) (int64, error) {
 	if t.dbmap.ExpandSliceArgs {
 		expandSliceArgs(&query, args...)
 	}
 
-	return SelectInt(t, query, args...)
+	return SelectInt(ctx, t, query, args...)
 }
 
 // SelectNullInt is a convenience wrapper around the borp.SelectNullInt function.
-func (t *Transaction) SelectNullInt(query string, args ...interface{}) (sql.NullInt64, error) {
+func (t *Transaction) SelectNullInt(ctx context.Context, query string, args ...interface{}) (sql.NullInt64, error) {
 	if t.dbmap.ExpandSliceArgs {
 		expandSliceArgs(&query, args...)
 	}
 
-	return SelectNullInt(t, query, args...)
+	return SelectNullInt(ctx, t, query, args...)
 }
 
 // SelectFloat is a convenience wrapper around the borp.SelectFloat function.
-func (t *Transaction) SelectFloat(query string, args ...interface{}) (float64, error) {
+func (t *Transaction) SelectFloat(ctx context.Context, query string, args ...interface{}) (float64, error) {
 	if t.dbmap.ExpandSliceArgs {
 		expandSliceArgs(&query, args...)
 	}
 
-	return SelectFloat(t, query, args...)
+	return SelectFloat(ctx, t, query, args...)
 }
 
 // SelectNullFloat is a convenience wrapper around the borp.SelectNullFloat function.
-func (t *Transaction) SelectNullFloat(query string, args ...interface{}) (sql.NullFloat64, error) {
+func (t *Transaction) SelectNullFloat(ctx context.Context, query string, args ...interface{}) (sql.NullFloat64, error) {
 	if t.dbmap.ExpandSliceArgs {
 		expandSliceArgs(&query, args...)
 	}
 
-	return SelectNullFloat(t, query, args...)
+	return SelectNullFloat(ctx, t, query, args...)
 }
 
 // SelectStr is a convenience wrapper around the borp.SelectStr function.
-func (t *Transaction) SelectStr(query string, args ...interface{}) (string, error) {
+func (t *Transaction) SelectStr(ctx context.Context, query string, args ...interface{}) (string, error) {
 	if t.dbmap.ExpandSliceArgs {
 		expandSliceArgs(&query, args...)
 	}
 
-	return SelectStr(t, query, args...)
+	return SelectStr(ctx, t, query, args...)
 }
 
 // SelectNullStr is a convenience wrapper around the borp.SelectNullStr function.
-func (t *Transaction) SelectNullStr(query string, args ...interface{}) (sql.NullString, error) {
+func (t *Transaction) SelectNullStr(ctx context.Context, query string, args ...interface{}) (sql.NullString, error) {
 	if t.dbmap.ExpandSliceArgs {
 		expandSliceArgs(&query, args...)
 	}
 
-	return SelectNullStr(t, query, args...)
+	return SelectNullStr(ctx, t, query, args...)
 }
 
 // SelectOne is a convenience wrapper around the borp.SelectOne function.
-func (t *Transaction) SelectOne(holder interface{}, query string, args ...interface{}) error {
+func (t *Transaction) SelectOne(ctx context.Context, holder interface{}, query string, args ...interface{}) error {
 	if t.dbmap.ExpandSliceArgs {
 		expandSliceArgs(&query, args...)
 	}
 
-	return SelectOne(t.dbmap, t, holder, query, args...)
+	return SelectOne(ctx, t.dbmap, t, holder, query, args...)
 }
 
 // Commit commits the underlying database transaction.
@@ -169,52 +161,52 @@ func (t *Transaction) Rollback() error {
 // Savepoint creates a savepoint with the given name. The name is interpolated
 // directly into the SQL SAVEPOINT statement, so you must sanitize it if it is
 // derived from user input.
-func (t *Transaction) Savepoint(name string) error {
+func (t *Transaction) Savepoint(ctx context.Context, name string) error {
 	query := "savepoint " + t.dbmap.Dialect.QuoteField(name)
 	if t.dbmap.logger != nil {
 		now := time.Now()
 		defer t.dbmap.trace(now, query, nil)
 	}
-	_, err := exec(t, query)
+	_, err := exec(ctx, t, query)
 	return err
 }
 
 // RollbackToSavepoint rolls back to the savepoint with the given name. The
 // name is interpolated directly into the SQL SAVEPOINT statement, so you must
 // sanitize it if it is derived from user input.
-func (t *Transaction) RollbackToSavepoint(savepoint string) error {
+func (t *Transaction) RollbackToSavepoint(ctx context.Context, savepoint string) error {
 	query := "rollback to savepoint " + t.dbmap.Dialect.QuoteField(savepoint)
 	if t.dbmap.logger != nil {
 		now := time.Now()
 		defer t.dbmap.trace(now, query, nil)
 	}
-	_, err := exec(t, query)
+	_, err := exec(ctx, t, query)
 	return err
 }
 
 // ReleaseSavepint releases the savepoint with the given name. The name is
 // interpolated directly into the SQL SAVEPOINT statement, so you must sanitize
 // it if it is derived from user input.
-func (t *Transaction) ReleaseSavepoint(savepoint string) error {
+func (t *Transaction) ReleaseSavepoint(ctx context.Context, savepoint string) error {
 	query := "release savepoint " + t.dbmap.Dialect.QuoteField(savepoint)
 	if t.dbmap.logger != nil {
 		now := time.Now()
 		defer t.dbmap.trace(now, query, nil)
 	}
-	_, err := exec(t, query)
+	_, err := exec(ctx, t, query)
 	return err
 }
 
 // Prepare has the same behavior as DbMap.Prepare(), but runs in a transaction.
-func (t *Transaction) Prepare(query string) (*sql.Stmt, error) {
+func (t *Transaction) PrepareContext(ctx context.Context, query string) (*sql.Stmt, error) {
 	if t.dbmap.logger != nil {
 		now := time.Now()
 		defer t.dbmap.trace(now, query, nil)
 	}
-	return prepare(t, query)
+	return prepare(ctx, t, query)
 }
 
-func (t *Transaction) QueryRow(query string, args ...interface{}) *sql.Row {
+func (t *Transaction) QueryRowContext(ctx context.Context, query string, args ...interface{}) *sql.Row {
 	if t.dbmap.ExpandSliceArgs {
 		expandSliceArgs(&query, args...)
 	}
@@ -223,10 +215,10 @@ func (t *Transaction) QueryRow(query string, args ...interface{}) *sql.Row {
 		now := time.Now()
 		defer t.dbmap.trace(now, query, args...)
 	}
-	return queryRow(t, query, args...)
+	return queryRow(ctx, t, query, args...)
 }
 
-func (t *Transaction) Query(q string, args ...interface{}) (*sql.Rows, error) {
+func (t *Transaction) QueryContext(ctx context.Context, q string, args ...interface{}) (*sql.Rows, error) {
 	if t.dbmap.ExpandSliceArgs {
 		expandSliceArgs(&q, args...)
 	}
@@ -235,5 +227,5 @@ func (t *Transaction) Query(q string, args ...interface{}) (*sql.Rows, error) {
 		now := time.Now()
 		defer t.dbmap.trace(now, q, args...)
 	}
-	return query(t, q, args...)
+	return query(ctx, t, q, args...)
 }

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -96,7 +96,7 @@ AND field12 IN (:FieldIntList)
 	dbmap.ExpandSliceArgs = true
 	dbmap.AddTableWithName(dataFormat{}, "crazy_table")
 
-	err := dbmap.CreateTables()
+	err := dbmap.CreateTables(context.Background())
 	if err != nil {
 		panic(err)
 	}
@@ -263,7 +263,7 @@ AND field12 IN (:FieldIntList)
 	dbmap.ExpandSliceArgs = true
 	dbmap.AddTableWithName(dataFormat{}, "crazy_table")
 
-	err := dbmap.CreateTables()
+	err := dbmap.CreateTables(context.Background())
 	if err != nil {
 		panic(err)
 	}

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -2,11 +2,15 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
+//go:build integration
 // +build integration
 
 package borp_test
 
-import "testing"
+import (
+	"context"
+	"testing"
+)
 
 func TestTransaction_Select_expandSliceArgs(t *testing.T) {
 	tests := []struct {
@@ -99,6 +103,7 @@ AND field12 IN (:FieldIntList)
 	defer dropAndClose(dbmap)
 
 	err = dbmap.Insert(
+		context.Background(),
 		&dataFormat{
 			Field1:  123,
 			Field2:  "h",
@@ -155,14 +160,14 @@ AND field12 IN (:FieldIntList)
 
 	for _, tt := range tests {
 		t.Run(tt.description, func(t *testing.T) {
-			tx, err := dbmap.Begin()
+			tx, err := dbmap.BeginTx(context.Background())
 			if err != nil {
 				t.Fatal(err)
 			}
 			defer tx.Rollback()
 
 			var dummy []int
-			_, err = tx.Select(&dummy, tt.query, tt.args...)
+			_, err = tx.Select(context.Background(), &dummy, tt.query, tt.args...)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -265,6 +270,7 @@ AND field12 IN (:FieldIntList)
 	defer dropAndClose(dbmap)
 
 	err = dbmap.Insert(
+		context.Background(),
 		&dataFormat{
 			Field1:  123,
 			Field2:  "h",
@@ -321,13 +327,13 @@ AND field12 IN (:FieldIntList)
 
 	for _, tt := range tests {
 		t.Run(tt.description, func(t *testing.T) {
-			tx, err := dbmap.Begin()
+			tx, err := dbmap.BeginTx(context.Background())
 			if err != nil {
 				t.Fatal(err)
 			}
 			defer tx.Rollback()
 
-			_, err = tx.Exec(tt.query, tt.args...)
+			_, err = tx.ExecContext(context.Background(), tt.query, tt.args...)
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
Building on #1, this modifies the API so all methods on SqlExecutor (and their corresponding methods on DbMap and Transaction) take a context as their first argument.

This removes the internal `ctx` field on DbMap and context, and removes `WithContext` from both.

This also renames Exec, Prepare, Query, and QueryRow on those structs to add `Context` at the end of the names, matching database/sql.