### PR TITLE
Check error return of rows.Close().

### DIFF
--- a/select.go
+++ b/select.go
@@ -168,7 +168,12 @@ func selectVal(e SqlExecutor, holder interface{}, query string, args ...interfac
 		return sql.ErrNoRows
 	}
 
-	return rows.Scan(holder)
+	err = rows.Scan(holder)
+	if err != nil {
+		return err
+	}
+
+	return rows.Close()
 }
 
 func hookedselect(m *DbMap, exec SqlExecutor, i interface{}, query string,
@@ -349,6 +354,11 @@ func rawselect(m *DbMap, exec SqlExecutor, i interface{}, query string,
 		} else {
 			list = append(list, v.Interface())
 		}
+	}
+
+	err = rows.Close()
+	if err != nil {
+		return nil, err
 	}
 
 	if appendToSlice && sliceValue.IsNil() {


### PR DESCRIPTION
According to
https://github.blog/2020-05-20-three-bugs-in-the-go-mysql-driver/, when QueryContext is called with a context that is cancelled during scan, you can receive incomplete or corrupted results. As I understand it, the corruption is fixed upstream, but it's still possible to get incomplete results that will only show up in the error result from Close.

It's still possible and correct to call `defer rows.Close()`, since the database/sql docs say this:

https://godoc.org/database/sql#Rows.Close

> Close is idempotent and does not affect the result of Err.

Note: This is a recreation of https://github.com/go-gorp/gorp/pull/420