### PR TITLE
Some staticcheck fixes

### DIFF
--- a/db.go
+++ b/db.go
@@ -822,7 +822,7 @@ func (m *DbMap) trace(started time.Time, query string, args ...interface{}) {
 
 	if m.logger != nil {
 		var margs = argsString(args...)
-		m.logger.Printf("%s%s [%s] (%v)", m.logPrefix, query, margs, (time.Now().Sub(started)))
+		m.logger.Printf("%s%s [%s] (%v)", m.logPrefix, query, margs, (time.Since(started)))
 	}
 }
 

--- a/gorp.go
+++ b/gorp.go
@@ -37,7 +37,6 @@ func (nt *dummyField) Scan(value interface{}) error {
 	return nil
 }
 
-var zeroVal reflect.Value
 var versFieldConst = "[gorp_ver_field]"
 
 // The TypeConverter interface provides a way to map a value of one
@@ -277,6 +276,7 @@ func fieldByName(val reflect.Value, fieldName string) *reflect.Value {
 	// try to find field by exact match
 	f := val.FieldByName(fieldName)
 
+	var zeroVal reflect.Value
 	if f != zeroVal {
 		return &f
 	}

--- a/table.go
+++ b/table.go
@@ -47,7 +47,6 @@ func (t *TableMap) ResetSql() {
 // Automatically calls ResetSql() to ensure SQL statements are regenerated.
 //
 // Panics if isAutoIncr is true, and fieldNames length != 1
-//
 func (t *TableMap) SetKeys(isAutoIncr bool, fieldNames ...string) *TableMap {
 	if isAutoIncr && len(fieldNames) != 1 {
 		panic(fmt.Sprintf(
@@ -73,17 +72,13 @@ func (t *TableMap) SetKeys(isAutoIncr bool, fieldNames ...string) *TableMap {
 // Automatically calls ResetSql() to ensure SQL statements are regenerated.
 //
 // Panics if fieldNames length < 2.
-//
 func (t *TableMap) SetUniqueTogether(fieldNames ...string) *TableMap {
 	if len(fieldNames) < 2 {
-		panic(fmt.Sprintf(
-			"gorp: SetUniqueTogether: must provide at least two fieldNames to set uniqueness constraint."))
+		panic("gorp: SetUniqueTogether: must provide at least two fieldNames to set uniqueness constraint.")
 	}
 
 	columns := make([]string, 0, len(fieldNames))
-	for _, name := range fieldNames {
-		columns = append(columns, name)
-	}
+	columns = append(columns, fieldNames...)
 
 	for _, existingColumns := range t.uniqueTogether {
 		if equal(existingColumns, columns) {
@@ -135,7 +130,6 @@ func (t *TableMap) IdxMap(field string) *IndexMap {
 // Function will panic if one of the given for index columns does not exists
 //
 // Automatically calls ResetSql() to ensure SQL statements are regenerated.
-//
 func (t *TableMap) AddIndex(name string, idxtype string, columns []string) *IndexMap {
 	// check if we have a index with this name already
 	for _, idx := range t.indexes {


### PR DESCRIPTION
I ran [staticcheck](https://staticcheck.dev/docs/checks) and fixed the following truncated list of warnings.
```
$ staticcheck 
db.go:823:65: should use time.Since instead of time.Now().Sub (S1012)
gorp.go:40:5: var zeroVal is unused (U1000)
table.go:79:9: unnecessary use of fmt.Sprintf (S1039)
table.go:84:2: should replace loop with columns = append(columns, fieldNames...) (S1011)
```