### PR TITLE
Run govulncheck in CI

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -74,4 +74,4 @@ jobs:
     - id: govulncheck
       uses: golang/govulncheck-action@v0.2.0
       with:
-        go-version: ${{ matrix.setupGoVer }}
+        go-version-input: ${{ matrix.setupGoVer }}

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -12,7 +12,6 @@ permissions:
   contents: read
 
 jobs:
-
   integration-tests:
     runs-on: ubuntu-latest
     container: golang:1.20
@@ -47,9 +46,15 @@ jobs:
       with:
         persist-credentials: false
 
-
     - name: Go Build
       run: go build -v ./...
 
     - name: Unit Tests
       run: go test -v ./...
+
+  gvc:
+    runs-on: ubuntu-latest
+    container: golang:1.20
+    steps:
+    - id: govulncheck
+      uses: golang/govulncheck-action@v0.2.0

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -63,15 +63,18 @@ jobs:
   gvc:
     strategy:
       matrix:
-        include:
-          - containerGoVer: "1.20"
-            setupGoVer: "1.20.5"
-          - containerGoVer: "1.21-rc"
-            setupGoVer: "1.21.0-rc.2" # https://github.com/actions/setup-go#v3
+        containerGoVer:
+          - "1.20"
+          - "1.21-rc"
     runs-on: ubuntu-latest
     container: golang:${{ matrix.containerGoVer }}
     steps:
-    - id: govulncheck
-      uses: golang/govulncheck-action@v0.2.0
-      with:
-        go-version-input: ${{ matrix.setupGoVer }}
+      - uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+
+      - name: Install govulncheck
+        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+
+      - name: Run govulncheck
+        run: govulncheck ./...

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -13,9 +13,13 @@ permissions:
 
 jobs:
   integration-tests:
+    strategy:
+      matrix:
+        containerGoVer:
+          - "1.20"
+          - "1.21-rc"
     runs-on: ubuntu-latest
-    container: golang:1.20
-
+    container: golang:${{ matrix.containerGoVer }}
     services:
       mysql:
         image: mariadb:10.5
@@ -29,7 +33,6 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 10
-
     steps:
       - uses: actions/checkout@v3
         with:
@@ -39,8 +42,13 @@ jobs:
         run: ./test_all.sh
 
   quick-tests:
+    strategy:
+      matrix:
+        containerGoVer:
+          - "1.20"
+          - "1.21-rc"
     runs-on: ubuntu-latest
-    container: golang:1.20
+    container: golang:${{ matrix.containerGoVer }}
     steps:
     - uses: actions/checkout@v3
       with:
@@ -53,8 +61,17 @@ jobs:
       run: go test -v ./...
 
   gvc:
+    strategy:
+      matrix:
+        include:
+          - containerGoVer: "1.20"
+            setupGoVer: "1.20.5"
+          - containerGoVer: "1.21-rc"
+            setupGoVer: "1.21.0-rc.2" # https://github.com/actions/setup-go#v3
     runs-on: ubuntu-latest
-    container: golang:1.20
+    container: golang:${{ matrix.containerGoVer }}
     steps:
     - id: govulncheck
       uses: golang/govulncheck-action@v0.2.0
+      with:
+        go-version: ${{ matrix.setupGoVer }}

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -60,7 +60,7 @@ jobs:
     - name: Unit Tests
       run: go test -v ./...
 
-  gvc:
+  govulncheck:
     strategy:
       matrix:
         containerGoVer:
@@ -73,8 +73,5 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Install govulncheck
-        run: go install golang.org/x/vuln/cmd/govulncheck@latest
-
       - name: Run govulncheck
-        run: govulncheck ./...
+        run: go run golang.org/x/vuln/cmd/govulncheck@latest ./...


### PR DESCRIPTION
Adds govulncheck to the CI workflow and tests against the same versions of golang as [boulder](https://github.com/letsencrypt/boulder/blob/cf770dfdef141c94507200ca803576d530481504/.github/workflows/boulder-ci.yml#L38-L40).