### PR TITLE
apply TypeConverter to args, not just fields

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,8 +16,8 @@ jobs:
     strategy:
       matrix:
         containerGoVer:
-          - "1.20"
-          - "1.21-rc"
+          - "1.21"
+          - "1.22"
     runs-on: ubuntu-latest
     container: golang:${{ matrix.containerGoVer }}
     services:
@@ -57,8 +57,8 @@ jobs:
     strategy:
       matrix:
         containerGoVer:
-          - "1.20"
-          - "1.21-rc"
+          - "1.21"
+          - "1.22"
     runs-on: ubuntu-latest
     container: golang:${{ matrix.containerGoVer }}
     steps:
@@ -76,8 +76,7 @@ jobs:
     strategy:
       matrix:
         containerGoVer:
-          - "1.20"
-          - "1.21-rc"
+          - "latest"
     runs-on: ubuntu-latest
     container: golang:${{ matrix.containerGoVer }}
     steps:

--- a/db.go
+++ b/db.go
@@ -597,7 +597,26 @@ func (m *DbMap) Select(ctx context.Context, i interface{}, query string, args ..
 		expandSliceArgs(&query, args...)
 	}
 
+	args, err := m.convertArgs(args...)
+	if err != nil {
+		return nil, err
+	}
+
 	return hookedselect(ctx, m, m, i, query, args...)
+}
+
+func (m *DbMap) convertArgs(args ...interface{}) ([]interface{}, error) {
+	if m.TypeConverter == nil {
+		return args, nil
+	}
+	for i, arg := range args {
+		converted, err := m.TypeConverter.ToDb(arg)
+		if err != nil {
+			return nil, err
+		}
+		args[i] = converted
+	}
+	return args, nil
 }
 
 // Exec runs an arbitrary SQL statement.  args represent the bind parameters.
@@ -605,6 +624,11 @@ func (m *DbMap) Select(ctx context.Context, i interface{}, query string, args ..
 func (m *DbMap) ExecContext(ctx context.Context, query string, args ...interface{}) (sql.Result, error) {
 	if m.ExpandSliceArgs {
 		expandSliceArgs(&query, args...)
+	}
+
+	args, err := m.convertArgs(args...)
+	if err != nil {
+		return nil, err
 	}
 
 	if m.logger != nil {
@@ -620,6 +644,11 @@ func (m *DbMap) SelectInt(ctx context.Context, query string, args ...interface{}
 		expandSliceArgs(&query, args...)
 	}
 
+	args, err := m.convertArgs(args...)
+	if err != nil {
+		return 0, err
+	}
+
 	return SelectInt(ctx, m, query, args...)
 }
 
@@ -627,6 +656,11 @@ func (m *DbMap) SelectInt(ctx context.Context, query string, args ...interface{}
 func (m *DbMap) SelectNullInt(ctx context.Context, query string, args ...interface{}) (sql.NullInt64, error) {
 	if m.ExpandSliceArgs {
 		expandSliceArgs(&query, args...)
+	}
+
+	args, err := m.convertArgs(args...)
+	if err != nil {
+		return sql.NullInt64{}, err
 	}
 
 	return SelectNullInt(ctx, m, query, args...)
@@ -638,6 +672,11 @@ func (m *DbMap) SelectFloat(ctx context.Context, query string, args ...interface
 		expandSliceArgs(&query, args...)
 	}
 
+	args, err := m.convertArgs(args...)
+	if err != nil {
+		return 0, err
+	}
+
 	return SelectFloat(ctx, m, query, args...)
 }
 
@@ -645,6 +684,11 @@ func (m *DbMap) SelectFloat(ctx context.Context, query string, args ...interface
 func (m *DbMap) SelectNullFloat(ctx context.Context, query string, args ...interface{}) (sql.NullFloat64, error) {
 	if m.ExpandSliceArgs {
 		expandSliceArgs(&query, args...)
+	}
+
+	args, err := m.convertArgs(args...)
+	if err != nil {
+		return sql.NullFloat64{}, err
 	}
 
 	return SelectNullFloat(ctx, m, query, args...)
@@ -656,6 +700,11 @@ func (m *DbMap) SelectStr(ctx context.Context, query string, args ...interface{}
 		expandSliceArgs(&query, args...)
 	}
 
+	args, err := m.convertArgs(args...)
+	if err != nil {
+		return "", err
+	}
+
 	return SelectStr(ctx, m, query, args...)
 }
 
@@ -665,6 +714,11 @@ func (m *DbMap) SelectNullStr(ctx context.Context, query string, args ...interfa
 		expandSliceArgs(&query, args...)
 	}
 
+	args, err := m.convertArgs(args...)
+	if err != nil {
+		return sql.NullString{}, err
+	}
+
 	return SelectNullStr(ctx, m, query, args...)
 }
 
@@ -672,6 +726,11 @@ func (m *DbMap) SelectNullStr(ctx context.Context, query string, args ...interfa
 func (m *DbMap) SelectOne(ctx context.Context, holder interface{}, query string, args ...interface{}) error {
 	if m.ExpandSliceArgs {
 		expandSliceArgs(&query, args...)
+	}
+
+	args, err := m.convertArgs(args...)
+	if err != nil {
+		return err
 	}
 
 	return SelectOne(ctx, m, m, holder, query, args...)
@@ -798,6 +857,11 @@ func (m *DbMap) QueryRowContext(ctx context.Context, query string, args ...inter
 		expandSliceArgs(&query, args...)
 	}
 
+	args, err := m.convertArgs(args...)
+	if err != nil {
+		return nil
+	}
+
 	if m.logger != nil {
 		now := time.Now()
 		defer m.trace(now, query, args...)
@@ -809,6 +873,11 @@ func (m *DbMap) QueryRowContext(ctx context.Context, query string, args ...inter
 func (m *DbMap) QueryContext(ctx context.Context, q string, args ...interface{}) (*sql.Rows, error) {
 	if m.ExpandSliceArgs {
 		expandSliceArgs(&q, args...)
+	}
+
+	args, err := m.convertArgs(args...)
+	if err != nil {
+		return nil, err
 	}
 
 	if m.logger != nil {

--- a/gorp_test.go
+++ b/gorp_test.go
@@ -1787,14 +1787,14 @@ func TestTypeConversionExample(t *testing.T) {
 	}
 
 	_, err = dbmap.SelectFloat(context.Background(),
-		"select id * 1.2 from type_conv_test where PersonJSON = "+dbmap.Dialect.BindVar(0)+" and Name = "+dbmap.Dialect.BindVar(1),
+		"select Id * 1.2 from type_conv_test where PersonJSON = "+dbmap.Dialect.BindVar(0)+" and Name = "+dbmap.Dialect.BindVar(1),
 		personJSON, hi2)
 	if err != nil {
 		t.Errorf("Select failed: %s", err)
 	}
 
 	_, err = dbmap.SelectNullFloat(context.Background(),
-		"select id * 1.2 from type_conv_test where PersonJSON = "+dbmap.Dialect.BindVar(0)+" and Name = "+dbmap.Dialect.BindVar(1),
+		"select Id * 1.2 from type_conv_test where PersonJSON = "+dbmap.Dialect.BindVar(0)+" and Name = "+dbmap.Dialect.BindVar(1),
 		personJSON, hi2)
 	if err != nil {
 		t.Errorf("Select failed: %s", err)

--- a/gorp_test.go
+++ b/gorp_test.go
@@ -1751,7 +1751,7 @@ func TestTypeConversionExample(t *testing.T) {
 	personJSON := Person{FName: "Jane", LName: "Doe"}
 	_, err := dbmap.Select(context.Background(),
 		holder,
-		"select * from type_conv_test where personjson = ? and name = ?",
+		"select * from type_conv_test where personjson = "+dbmap.Dialect.BindVar(0)+" and name = "+dbmap.Dialect.BindVar(1),
 		personJSON, hi2)
 	if err != nil {
 		t.Errorf("Select failed: %s", err)
@@ -1759,78 +1759,78 @@ func TestTypeConversionExample(t *testing.T) {
 
 	err = dbmap.SelectOne(context.Background(),
 		&holder,
-		"select * from type_conv_test where personjson = ? and name = ?",
+		"select * from type_conv_test where personjson = "+dbmap.Dialect.BindVar(0)+" and name = "+dbmap.Dialect.BindVar(1),
 		personJSON, hi2)
 	if err != nil {
 		t.Errorf("Select failed: %s", err)
 	}
 
 	_, err = dbmap.SelectInt(context.Background(),
-		"select id from type_conv_test where personjson = ? and name = ?",
+		"select id from type_conv_test where personjson = "+dbmap.Dialect.BindVar(0)+" and name = "+dbmap.Dialect.BindVar(1),
 		personJSON, hi2)
 	if err != nil {
 		t.Errorf("Select failed: %s", err)
 	}
 
 	_, err = dbmap.SelectInt(context.Background(),
-		"select id from type_conv_test where personjson = ? and name = ?",
+		"select id from type_conv_test where personjson = "+dbmap.Dialect.BindVar(0)+" and name = "+dbmap.Dialect.BindVar(1),
 		personJSON, hi2)
 	if err != nil {
 		t.Errorf("Select failed: %s", err)
 	}
 
 	_, err = dbmap.SelectNullInt(context.Background(),
-		"select id from type_conv_test where personjson = ? and name = ?",
+		"select id from type_conv_test where personjson = "+dbmap.Dialect.BindVar(0)+" and name = "+dbmap.Dialect.BindVar(1),
 		personJSON, hi2)
 	if err != nil {
 		t.Errorf("Select failed: %s", err)
 	}
 
 	_, err = dbmap.SelectFloat(context.Background(),
-		"select id * 1.2 from type_conv_test where personjson = ? and name = ?",
+		"select id * 1.2 from type_conv_test where personjson = "+dbmap.Dialect.BindVar(0)+" and name = "+dbmap.Dialect.BindVar(1),
 		personJSON, hi2)
 	if err != nil {
 		t.Errorf("Select failed: %s", err)
 	}
 
 	_, err = dbmap.SelectNullFloat(context.Background(),
-		"select id * 1.2 from type_conv_test where personjson = ? and name = ?",
+		"select id * 1.2 from type_conv_test where personjson = "+dbmap.Dialect.BindVar(0)+" and name = "+dbmap.Dialect.BindVar(1),
 		personJSON, hi2)
 	if err != nil {
 		t.Errorf("Select failed: %s", err)
 	}
 
 	_, err = dbmap.SelectStr(context.Background(),
-		"select name from type_conv_test where personjson = ? and name = ?",
+		"select name from type_conv_test where personjson = "+dbmap.Dialect.BindVar(0)+" and name = "+dbmap.Dialect.BindVar(1),
 		personJSON, hi2)
 	if err != nil {
 		t.Errorf("Select failed: %s", err)
 	}
 
 	_, err = dbmap.SelectNullStr(context.Background(),
-		"select name from type_conv_test where personjson = ? and name = ?",
+		"select name from type_conv_test where personjson = "+dbmap.Dialect.BindVar(0)+" and name = "+dbmap.Dialect.BindVar(1),
 		personJSON, hi2)
 	if err != nil {
 		t.Errorf("Select failed: %s", err)
 	}
 
 	_, err = dbmap.QueryContext(context.Background(),
-		"select name from type_conv_test where personjson = ? and name = ?",
+		"select name from type_conv_test where personjson = "+dbmap.Dialect.BindVar(0)+" and name = "+dbmap.Dialect.BindVar(1),
 		personJSON, hi2)
 	if err != nil {
 		t.Errorf("Select failed: %s", err)
 	}
 
 	row := dbmap.QueryRowContext(context.Background(),
-		"select name from type_conv_test where personjson = ?",
-		personJSON)
+		"select name from type_conv_test where personjson = "+dbmap.Dialect.BindVar(0)+" and name = "+dbmap.Dialect.BindVar(1),
+		personJSON, hi2)
 	if row == nil || row.Err() != nil {
 		t.Errorf("QueryRowContext failed: %s", row.Err())
 	}
 
 	_, err = dbmap.ExecContext(context.Background(),
-		"select name from type_conv_test where personjson = ?",
-		personJSON)
+		"select name from type_conv_test where personjson = "+dbmap.Dialect.BindVar(0)+" and name = "+dbmap.Dialect.BindVar(1),
+		personJSON, hi2)
 	if err != nil {
 		t.Errorf("Select failed: %s", err)
 	}

--- a/gorp_test.go
+++ b/gorp_test.go
@@ -1734,7 +1734,8 @@ func TestTypeConversionExample(t *testing.T) {
 		t.Errorf("tc2 %v != %v", expected, tc2)
 	}
 
-	tc2.Name = CustomStringType("hi2")
+	hi2 := CustomStringType("hi2")
+	tc2.Name = hi2
 	tc2.PersonJSON = Person{FName: "Jane", LName: "Doe"}
 	_update(dbmap, tc2)
 
@@ -1750,73 +1751,72 @@ func TestTypeConversionExample(t *testing.T) {
 	personJSON := Person{FName: "Jane", LName: "Doe"}
 	_, err := dbmap.Select(context.Background(),
 		holder,
-		"select * from type_conv_test where personjson = ?",
-		personJSON,
-	)
+		"select * from type_conv_test where personjson = ? and name = ?",
+		personJSON, hi2)
 	if err != nil {
 		t.Errorf("Select failed: %s", err)
 	}
 
 	err = dbmap.SelectOne(context.Background(),
 		&holder,
-		"select * from type_conv_test where personjson = ?",
-		personJSON)
+		"select * from type_conv_test where personjson = ? and name = ?",
+		personJSON, hi2)
 	if err != nil {
 		t.Errorf("Select failed: %s", err)
 	}
 
 	_, err = dbmap.SelectInt(context.Background(),
-		"select id from type_conv_test where personjson = ?",
-		personJSON)
+		"select id from type_conv_test where personjson = ? and name = ?",
+		personJSON, hi2)
 	if err != nil {
 		t.Errorf("Select failed: %s", err)
 	}
 
 	_, err = dbmap.SelectInt(context.Background(),
-		"select id from type_conv_test where personjson = ?",
-		personJSON)
+		"select id from type_conv_test where personjson = ? and name = ?",
+		personJSON, hi2)
 	if err != nil {
 		t.Errorf("Select failed: %s", err)
 	}
 
 	_, err = dbmap.SelectNullInt(context.Background(),
-		"select id from type_conv_test where personjson = ?",
-		personJSON)
+		"select id from type_conv_test where personjson = ? and name = ?",
+		personJSON, hi2)
 	if err != nil {
 		t.Errorf("Select failed: %s", err)
 	}
 
 	_, err = dbmap.SelectFloat(context.Background(),
-		"select id * 1.2 from type_conv_test where personjson = ?",
-		personJSON)
+		"select id * 1.2 from type_conv_test where personjson = ? and name = ?",
+		personJSON, hi2)
 	if err != nil {
 		t.Errorf("Select failed: %s", err)
 	}
 
 	_, err = dbmap.SelectNullFloat(context.Background(),
-		"select id * 1.2 from type_conv_test where personjson = ?",
-		personJSON)
+		"select id * 1.2 from type_conv_test where personjson = ? and name = ?",
+		personJSON, hi2)
 	if err != nil {
 		t.Errorf("Select failed: %s", err)
 	}
 
 	_, err = dbmap.SelectStr(context.Background(),
-		"select name from type_conv_test where personjson = ?",
-		personJSON)
+		"select name from type_conv_test where personjson = ? and name = ?",
+		personJSON, hi2)
 	if err != nil {
 		t.Errorf("Select failed: %s", err)
 	}
 
 	_, err = dbmap.SelectNullStr(context.Background(),
-		"select name from type_conv_test where personjson = ?",
-		personJSON)
+		"select name from type_conv_test where personjson = ? and name = ?",
+		personJSON, hi2)
 	if err != nil {
 		t.Errorf("Select failed: %s", err)
 	}
 
 	_, err = dbmap.QueryContext(context.Background(),
-		"select name from type_conv_test where personjson = ?",
-		personJSON)
+		"select name from type_conv_test where personjson = ? and name = ?",
+		personJSON, hi2)
 	if err != nil {
 		t.Errorf("Select failed: %s", err)
 	}

--- a/gorp_test.go
+++ b/gorp_test.go
@@ -1751,7 +1751,7 @@ func TestTypeConversionExample(t *testing.T) {
 	personJSON := Person{FName: "Jane", LName: "Doe"}
 	_, err := dbmap.Select(context.Background(),
 		holder,
-		"select * from type_conv_test where personjson = "+dbmap.Dialect.BindVar(0)+" and name = "+dbmap.Dialect.BindVar(1),
+		"select * from type_conv_test where PersonJSON = "+dbmap.Dialect.BindVar(0)+" and Name = "+dbmap.Dialect.BindVar(1),
 		personJSON, hi2)
 	if err != nil {
 		t.Errorf("Select failed: %s", err)
@@ -1759,77 +1759,77 @@ func TestTypeConversionExample(t *testing.T) {
 
 	err = dbmap.SelectOne(context.Background(),
 		&holder,
-		"select * from type_conv_test where personjson = "+dbmap.Dialect.BindVar(0)+" and name = "+dbmap.Dialect.BindVar(1),
+		"select * from type_conv_test where PersonJSON = "+dbmap.Dialect.BindVar(0)+" and Name = "+dbmap.Dialect.BindVar(1),
 		personJSON, hi2)
 	if err != nil {
 		t.Errorf("Select failed: %s", err)
 	}
 
 	_, err = dbmap.SelectInt(context.Background(),
-		"select id from type_conv_test where personjson = "+dbmap.Dialect.BindVar(0)+" and name = "+dbmap.Dialect.BindVar(1),
+		"select id from type_conv_test where PersonJSON = "+dbmap.Dialect.BindVar(0)+" and Name = "+dbmap.Dialect.BindVar(1),
 		personJSON, hi2)
 	if err != nil {
 		t.Errorf("Select failed: %s", err)
 	}
 
 	_, err = dbmap.SelectInt(context.Background(),
-		"select id from type_conv_test where personjson = "+dbmap.Dialect.BindVar(0)+" and name = "+dbmap.Dialect.BindVar(1),
+		"select id from type_conv_test where PersonJSON = "+dbmap.Dialect.BindVar(0)+" and Name = "+dbmap.Dialect.BindVar(1),
 		personJSON, hi2)
 	if err != nil {
 		t.Errorf("Select failed: %s", err)
 	}
 
 	_, err = dbmap.SelectNullInt(context.Background(),
-		"select id from type_conv_test where personjson = "+dbmap.Dialect.BindVar(0)+" and name = "+dbmap.Dialect.BindVar(1),
+		"select id from type_conv_test where PersonJSON = "+dbmap.Dialect.BindVar(0)+" and Name = "+dbmap.Dialect.BindVar(1),
 		personJSON, hi2)
 	if err != nil {
 		t.Errorf("Select failed: %s", err)
 	}
 
 	_, err = dbmap.SelectFloat(context.Background(),
-		"select id * 1.2 from type_conv_test where personjson = "+dbmap.Dialect.BindVar(0)+" and name = "+dbmap.Dialect.BindVar(1),
+		"select id * 1.2 from type_conv_test where PersonJSON = "+dbmap.Dialect.BindVar(0)+" and Name = "+dbmap.Dialect.BindVar(1),
 		personJSON, hi2)
 	if err != nil {
 		t.Errorf("Select failed: %s", err)
 	}
 
 	_, err = dbmap.SelectNullFloat(context.Background(),
-		"select id * 1.2 from type_conv_test where personjson = "+dbmap.Dialect.BindVar(0)+" and name = "+dbmap.Dialect.BindVar(1),
+		"select id * 1.2 from type_conv_test where PersonJSON = "+dbmap.Dialect.BindVar(0)+" and Name = "+dbmap.Dialect.BindVar(1),
 		personJSON, hi2)
 	if err != nil {
 		t.Errorf("Select failed: %s", err)
 	}
 
 	_, err = dbmap.SelectStr(context.Background(),
-		"select name from type_conv_test where personjson = "+dbmap.Dialect.BindVar(0)+" and name = "+dbmap.Dialect.BindVar(1),
+		"select name from type_conv_test where PersonJSON = "+dbmap.Dialect.BindVar(0)+" and Name = "+dbmap.Dialect.BindVar(1),
 		personJSON, hi2)
 	if err != nil {
 		t.Errorf("Select failed: %s", err)
 	}
 
 	_, err = dbmap.SelectNullStr(context.Background(),
-		"select name from type_conv_test where personjson = "+dbmap.Dialect.BindVar(0)+" and name = "+dbmap.Dialect.BindVar(1),
+		"select name from type_conv_test where PersonJSON = "+dbmap.Dialect.BindVar(0)+" and Name = "+dbmap.Dialect.BindVar(1),
 		personJSON, hi2)
 	if err != nil {
 		t.Errorf("Select failed: %s", err)
 	}
 
 	_, err = dbmap.QueryContext(context.Background(),
-		"select name from type_conv_test where personjson = "+dbmap.Dialect.BindVar(0)+" and name = "+dbmap.Dialect.BindVar(1),
+		"select name from type_conv_test where PersonJSON = "+dbmap.Dialect.BindVar(0)+" and Name = "+dbmap.Dialect.BindVar(1),
 		personJSON, hi2)
 	if err != nil {
 		t.Errorf("Select failed: %s", err)
 	}
 
 	row := dbmap.QueryRowContext(context.Background(),
-		"select name from type_conv_test where personjson = "+dbmap.Dialect.BindVar(0)+" and name = "+dbmap.Dialect.BindVar(1),
+		"select name from type_conv_test where PersonJSON = "+dbmap.Dialect.BindVar(0)+" and Name = "+dbmap.Dialect.BindVar(1),
 		personJSON, hi2)
 	if row == nil || row.Err() != nil {
 		t.Errorf("QueryRowContext failed: %s", row.Err())
 	}
 
 	_, err = dbmap.ExecContext(context.Background(),
-		"select name from type_conv_test where personjson = "+dbmap.Dialect.BindVar(0)+" and name = "+dbmap.Dialect.BindVar(1),
+		"select name from type_conv_test where PersonJSON = "+dbmap.Dialect.BindVar(0)+" and Name = "+dbmap.Dialect.BindVar(1),
 		personJSON, hi2)
 	if err != nil {
 		t.Errorf("Select failed: %s", err)

--- a/gorp_test.go
+++ b/gorp_test.go
@@ -1744,10 +1744,100 @@ func TestTypeConversionExample(t *testing.T) {
 		t.Errorf("tc3 %v != %v", expected, tc3)
 	}
 
+	// Test that the Person argument to Select goes through the
+	// type converter
+	var holder TypeConversionExample
+	personJSON := Person{FName: "Jane", LName: "Doe"}
+	_, err := dbmap.Select(context.Background(),
+		holder,
+		"select * from type_conv_test where personjson = ?",
+		personJSON,
+	)
+	if err != nil {
+		t.Errorf("Select failed: %s", err)
+	}
+
+	err = dbmap.SelectOne(context.Background(),
+		&holder,
+		"select * from type_conv_test where personjson = ?",
+		personJSON)
+	if err != nil {
+		t.Errorf("Select failed: %s", err)
+	}
+
+	_, err = dbmap.SelectInt(context.Background(),
+		"select id from type_conv_test where personjson = ?",
+		personJSON)
+	if err != nil {
+		t.Errorf("Select failed: %s", err)
+	}
+
+	_, err = dbmap.SelectInt(context.Background(),
+		"select id from type_conv_test where personjson = ?",
+		personJSON)
+	if err != nil {
+		t.Errorf("Select failed: %s", err)
+	}
+
+	_, err = dbmap.SelectNullInt(context.Background(),
+		"select id from type_conv_test where personjson = ?",
+		personJSON)
+	if err != nil {
+		t.Errorf("Select failed: %s", err)
+	}
+
+	_, err = dbmap.SelectFloat(context.Background(),
+		"select id * 1.2 from type_conv_test where personjson = ?",
+		personJSON)
+	if err != nil {
+		t.Errorf("Select failed: %s", err)
+	}
+
+	_, err = dbmap.SelectNullFloat(context.Background(),
+		"select id * 1.2 from type_conv_test where personjson = ?",
+		personJSON)
+	if err != nil {
+		t.Errorf("Select failed: %s", err)
+	}
+
+	_, err = dbmap.SelectStr(context.Background(),
+		"select name from type_conv_test where personjson = ?",
+		personJSON)
+	if err != nil {
+		t.Errorf("Select failed: %s", err)
+	}
+
+	_, err = dbmap.SelectNullStr(context.Background(),
+		"select name from type_conv_test where personjson = ?",
+		personJSON)
+	if err != nil {
+		t.Errorf("Select failed: %s", err)
+	}
+
+	_, err = dbmap.QueryContext(context.Background(),
+		"select name from type_conv_test where personjson = ?",
+		personJSON)
+	if err != nil {
+		t.Errorf("Select failed: %s", err)
+	}
+
+	row := dbmap.QueryRowContext(context.Background(),
+		"select name from type_conv_test where personjson = ?",
+		personJSON)
+	if row == nil || row.Err() != nil {
+		t.Errorf("QueryRowContext failed: %s", row.Err())
+	}
+
+	_, err = dbmap.ExecContext(context.Background(),
+		"select name from type_conv_test where personjson = ?",
+		personJSON)
+	if err != nil {
+		t.Errorf("Select failed: %s", err)
+	}
+
 	if _del(dbmap, tc) != 1 {
 		t.Errorf("Did not delete row with Id: %d", tc.Id)
 	}
-
 }
 
 func TestWithEmbeddedStruct(t *testing.T) {

--- a/gorp_test.go
+++ b/gorp_test.go
@@ -1745,94 +1745,101 @@ func TestTypeConversionExample(t *testing.T) {
 		t.Errorf("tc3 %v != %v", expected, tc3)
 	}
 
+	d := dbmap.Dialect
+	pj := d.QuoteField("PersonJSON")
+	id := d.QuoteField("Id")
+	name := d.QuoteField("Name")
+	bv0 := d.BindVar(0)
+	bv1 := d.BindVar(1)
+
 	// Test that the Person argument to Select goes through the
 	// type converter
 	var holder TypeConversionExample
 	personJSON := Person{FName: "Jane", LName: "Doe"}
 	_, err := dbmap.Select(context.Background(),
 		holder,
-		"select * from type_conv_test where PersonJSON = "+dbmap.Dialect.BindVar(0)+" and Name = "+dbmap.Dialect.BindVar(1),
+		`select * from type_conv_test where `+pj+`=`+bv0+` and `+name+`=`+bv1,
 		personJSON, hi2)
 	if err != nil {
-		t.Errorf("Select failed: %s", err)
+		t.Errorf(`Select failed: %s`, err)
 	}
 
 	err = dbmap.SelectOne(context.Background(),
 		&holder,
-		"select * from type_conv_test where PersonJSON = "+dbmap.Dialect.BindVar(0)+" and Name = "+dbmap.Dialect.BindVar(1),
+		`select * from type_conv_test where `+pj+`=`+bv0+` and `+name+`=`+bv1,
 		personJSON, hi2)
 	if err != nil {
-		t.Errorf("Select failed: %s", err)
+		t.Errorf(`Select failed: %s`, err)
 	}
 
 	_, err = dbmap.SelectInt(context.Background(),
-		"select Id from type_conv_test where PersonJSON = "+dbmap.Dialect.BindVar(0)+" and Name = "+dbmap.Dialect.BindVar(1),
+		`select `+id+` from type_conv_test where `+pj+`=`+bv0+` and `+name+`=`+bv1,
 		personJSON, hi2)
 	if err != nil {
-		t.Errorf("Select failed: %s", err)
+		t.Errorf(`Select failed: %s`, err)
 	}
 
 	_, err = dbmap.SelectInt(context.Background(),
-		"select Id from type_conv_test where PersonJSON = "+dbmap.Dialect.BindVar(0)+" and Name = "+dbmap.Dialect.BindVar(1),
+		`select `+id+` from type_conv_test where `+pj+`=`+bv0+` and `+name+`=`+bv1,
 		personJSON, hi2)
 	if err != nil {
-		t.Errorf("Select failed: %s", err)
+		t.Errorf(`Select failed: %s`, err)
 	}
 
 	_, err = dbmap.SelectNullInt(context.Background(),
-		"select Id from type_conv_test where PersonJSON = "+dbmap.Dialect.BindVar(0)+" and Name = "+dbmap.Dialect.BindVar(1),
+		`select `+id+` from type_conv_test where `+pj+`=`+bv0+` and `+name+`=`+bv1,
 		personJSON, hi2)
 	if err != nil {
-		t.Errorf("Select failed: %s", err)
+		t.Errorf(`Select failed: %s`, err)
 	}
 
 	_, err = dbmap.SelectFloat(context.Background(),
-		"select Id * 1.2 from type_conv_test where PersonJSON = "+dbmap.Dialect.BindVar(0)+" and Name = "+dbmap.Dialect.BindVar(1),
+		`select `+id+` from type_conv_test where `+pj+`=`+bv0+` and `+name+`=`+bv1,
 		personJSON, hi2)
 	if err != nil {
-		t.Errorf("Select failed: %s", err)
+		t.Errorf(`Select failed: %s`, err)
 	}
 
 	_, err = dbmap.SelectNullFloat(context.Background(),
-		"select Id * 1.2 from type_conv_test where PersonJSON = "+dbmap.Dialect.BindVar(0)+" and Name = "+dbmap.Dialect.BindVar(1),
+		`select `+id+` from type_conv_test where `+pj+`=`+bv0+` and `+name+`=`+bv1,
 		personJSON, hi2)
 	if err != nil {
-		t.Errorf("Select failed: %s", err)
+		t.Errorf(`Select failed: %s`, err)
 	}
 
 	_, err = dbmap.SelectStr(context.Background(),
-		"select name from type_conv_test where PersonJSON = "+dbmap.Dialect.BindVar(0)+" and Name = "+dbmap.Dialect.BindVar(1),
+		`select `+name+` from type_conv_test where `+pj+`=`+bv0+` and `+name+`=`+bv1,
 		personJSON, hi2)
 	if err != nil {
-		t.Errorf("Select failed: %s", err)
+		t.Errorf(`Select failed: %s`, err)
 	}
 
 	_, err = dbmap.SelectNullStr(context.Background(),
-		"select name from type_conv_test where PersonJSON = "+dbmap.Dialect.BindVar(0)+" and Name = "+dbmap.Dialect.BindVar(1),
+		`select `+name+` from type_conv_test where `+pj+`=`+bv0+` and `+name+`=`+bv1,
 		personJSON, hi2)
 	if err != nil {
-		t.Errorf("Select failed: %s", err)
+		t.Errorf(`Select failed: %s`, err)
 	}
 
 	_, err = dbmap.QueryContext(context.Background(),
-		"select name from type_conv_test where PersonJSON = "+dbmap.Dialect.BindVar(0)+" and Name = "+dbmap.Dialect.BindVar(1),
+		`select `+name+` from type_conv_test where `+pj+`=`+bv0+` and `+name+`=`+bv1,
 		personJSON, hi2)
 	if err != nil {
-		t.Errorf("Select failed: %s", err)
+		t.Errorf(`Select failed: %s`, err)
 	}
 
 	row := dbmap.QueryRowContext(context.Background(),
-		"select name from type_conv_test where PersonJSON = "+dbmap.Dialect.BindVar(0)+" and Name = "+dbmap.Dialect.BindVar(1),
+		`select `+name+` from type_conv_test where `+pj+`=`+bv0+` and `+name+`=`+bv1,
 		personJSON, hi2)
 	if row == nil || row.Err() != nil {
-		t.Errorf("QueryRowContext failed: %s", row.Err())
+		t.Errorf(`QueryRowContext failed: %s`, row.Err())
 	}
 
 	_, err = dbmap.ExecContext(context.Background(),
-		"select name from type_conv_test where PersonJSON = "+dbmap.Dialect.BindVar(0)+" and Name = "+dbmap.Dialect.BindVar(1),
+		`select `+name+` from type_conv_test where `+pj+`=`+bv0+` and `+name+`=`+bv1,
 		personJSON, hi2)
 	if err != nil {
-		t.Errorf("Select failed: %s", err)
+		t.Errorf(`Select failed: %s`, err)
 	}
 
 	if _del(dbmap, tc) != 1 {

--- a/gorp_test.go
+++ b/gorp_test.go
@@ -1766,21 +1766,21 @@ func TestTypeConversionExample(t *testing.T) {
 	}
 
 	_, err = dbmap.SelectInt(context.Background(),
-		"select id from type_conv_test where PersonJSON = "+dbmap.Dialect.BindVar(0)+" and Name = "+dbmap.Dialect.BindVar(1),
+		"select Id from type_conv_test where PersonJSON = "+dbmap.Dialect.BindVar(0)+" and Name = "+dbmap.Dialect.BindVar(1),
 		personJSON, hi2)
 	if err != nil {
 		t.Errorf("Select failed: %s", err)
 	}
 
 	_, err = dbmap.SelectInt(context.Background(),
-		"select id from type_conv_test where PersonJSON = "+dbmap.Dialect.BindVar(0)+" and Name = "+dbmap.Dialect.BindVar(1),
+		"select Id from type_conv_test where PersonJSON = "+dbmap.Dialect.BindVar(0)+" and Name = "+dbmap.Dialect.BindVar(1),
 		personJSON, hi2)
 	if err != nil {
 		t.Errorf("Select failed: %s", err)
 	}
 
 	_, err = dbmap.SelectNullInt(context.Background(),
-		"select id from type_conv_test where PersonJSON = "+dbmap.Dialect.BindVar(0)+" and Name = "+dbmap.Dialect.BindVar(1),
+		"select Id from type_conv_test where PersonJSON = "+dbmap.Dialect.BindVar(0)+" and Name = "+dbmap.Dialect.BindVar(1),
 		personJSON, hi2)
 	if err != nil {
 		t.Errorf("Select failed: %s", err)


### PR DESCRIPTION
This allows using custom types in query parameters. It also allows performing custom transformations on standard types (like rounding times to the second).