### PR TITLE
Get(): don't hide an sql.ErrNoRows error.

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,8 +293,7 @@ count, err := dbmap.Delete(inv1)
 
 ### Select by Key
 
-Use the `Get` method to fetch a single row by primary key.  It returns
-nil if no row is found.
+Use the `Get` method to fetch a single row by primary key.
 
 ```go
 // fetch Invoice with Id=99

--- a/db.go
+++ b/db.go
@@ -565,9 +565,9 @@ func (m *DbMap) Delete(ctx context.Context, list ...interface{}) (int64, error) 
 // The hook function PostGet() will be executed after the SELECT
 // statement if the interface defines them.
 //
-// Returns a pointer to a struct that matches or nil if no row is found.
+// Returns a pointer to a struct that matches.
 //
-// Returns an error if SetKeys has not been called on the TableMap
+// Returns an error if SetKeys has not been called on the TableMap or no row is found.
 // Panics if any interface in the list has not been registered with AddTable
 func (m *DbMap) Get(ctx context.Context, i interface{}, keys ...interface{}) (interface{}, error) {
 	return get(ctx, m, m, i, keys...)

--- a/gorp.go
+++ b/gorp.go
@@ -396,9 +396,6 @@ func get(ctx context.Context, m *DbMap, exec SqlExecutor, i interface{},
 	row := exec.QueryRowContext(ctx, plan.query, keys...)
 	err = row.Scan(dest...)
 	if err != nil {
-		if err == sql.ErrNoRows {
-			err = nil
-		}
 		return nil, err
 	}
 

--- a/gorp_test.go
+++ b/gorp_test.go
@@ -3026,6 +3026,9 @@ func _del(dbmap *borp.DbMap, list ...interface{}) int64 {
 
 func _get(dbmap *borp.DbMap, i interface{}, keys ...interface{}) interface{} {
 	obj, err := dbmap.Get(context.Background(), i, keys...)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil
+	}
 	if err != nil {
 		panic(err)
 	}

--- a/gorp_test.go
+++ b/gorp_test.go
@@ -656,7 +656,7 @@ func dynamicTablesTestDelete(t *testing.T,
 	// Try reading again to make sure instance is gone from db
 	getInst := TenantDynamic{curTable: inpInst.TableName()}
 	dbInst, err := dbmap.Get(context.Background(), &getInst, inpInst.Id)
-	if err != nil {
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		t.Errorf("Error while trying to read deleted %v object using id: %v",
 			inpInst.TableName(), inpInst.Id)
 	}


### PR DESCRIPTION
The behaviour for `Get()` was notably different than `SelectOne()`. `Get()` filters `ErrNoRows` and returns a `nil` object instead. `SelectOne()` takes a successful result that returned no rows, and specifically returns `sql.ErrNoRows` for it.

Consolidate on returning `ErrNoRows`.

Note that there are a number of other functions that share `Get()`'s behavior of returning a default value on `ErrNoRows`:

 - SelectFloat
 - SelectNullFloat
 - SelectInt
 - SelectNullInt
 - SelectStr
 - SelectNullStr
 
 I haven't touched these in this PR. They are mostly unused in Boulder, with the small exception of SelectNullInt. My plan is to remove all references to these from Boulder, then remove them from this repo.