### PR TITLE
Remove UpdateColumns

### DIFF
--- a/db.go
+++ b/db.go
@@ -521,23 +521,7 @@ func (m *DbMap) Insert(ctx context.Context, list ...interface{}) error {
 // Returns an error if SetKeys has not been called on the TableMap
 // Panics if any interface in the list has not been registered with AddTable
 func (m *DbMap) Update(ctx context.Context, list ...interface{}) (int64, error) {
-	return update(ctx, m, m, nil, list...)
-}
-
-// UpdateColumns runs a SQL UPDATE statement for each element in list.  List
-// items must be pointers.
-//
-// Only the columns accepted by filter are included in the UPDATE.
-//
-// The hook functions PreUpdate() and/or PostUpdate() will be executed
-// before/after the UPDATE statement if the interface defines them.
-//
-// Returns the number of rows updated.
-//
-// Returns an error if SetKeys has not been called on the TableMap
-// Panics if any interface in the list has not been registered with AddTable
-func (m *DbMap) UpdateColumns(ctx context.Context, filter ColumnFilter, list ...interface{}) (int64, error) {
-	return update(ctx, m, m, filter, list...)
+	return update(ctx, m, m, list...)
 }
 
 // Delete runs a SQL DELETE statement for each element in list.  List

--- a/gorp.go
+++ b/gorp.go
@@ -458,7 +458,7 @@ func delete(ctx context.Context, m *DbMap, exec SqlExecutor, list ...interface{}
 	return count, nil
 }
 
-func update(ctx context.Context, m *DbMap, exec SqlExecutor, colFilter ColumnFilter, list ...interface{}) (int64, error) {
+func update(ctx context.Context, m *DbMap, exec SqlExecutor, list ...interface{}) (int64, error) {
 	count := int64(0)
 	for _, ptr := range list {
 		table, elem, err := m.tableForPointer(ptr, true)
@@ -474,7 +474,7 @@ func update(ctx context.Context, m *DbMap, exec SqlExecutor, colFilter ColumnFil
 			}
 		}
 
-		bi, err := table.bindUpdate(elem, colFilter)
+		bi, err := table.bindUpdate(elem)
 		if err != nil {
 			return -1, err
 		}

--- a/gorp_test.go
+++ b/gorp_test.go
@@ -1700,29 +1700,6 @@ func TestWithIgnoredColumn(t *testing.T) {
 	}
 }
 
-func TestColumnFilter(t *testing.T) {
-	dbmap := initDBMap(t)
-	defer dropAndClose(dbmap)
-
-	inv1 := &Invoice{0, 100, 200, "a", 0, false}
-	_insert(dbmap, inv1)
-
-	inv1.Memo = "c"
-	inv1.IsPaid = true
-	_updateColumns(dbmap, func(col *borp.ColumnMap) bool {
-		return col.ColumnName == "Memo"
-	}, inv1)
-
-	inv2 := &Invoice{}
-	inv2 = _get(dbmap, inv2, inv1.Id).(*Invoice)
-	if inv2.Memo != "c" {
-		t.Errorf("Expected column to be updated (%#v)", inv2)
-	}
-	if inv2.IsPaid {
-		t.Error("IsPaid shouldn't have been updated")
-	}
-}
-
 func TestTypeConversionDBMapExample(t *testing.T) {
 	dbmap := initDBMap(t)
 	defer dropAndClose(dbmap)
@@ -2965,14 +2942,6 @@ func _insert(dbmap *borp.DbMap, list ...interface{}) {
 
 func _update(dbmap *borp.DbMap, list ...interface{}) int64 {
 	count, err := dbmap.Update(context.Background(), list...)
-	if err != nil {
-		panic(err)
-	}
-	return count
-}
-
-func _updateColumns(dbmap *borp.DbMap, filter borp.ColumnFilter, list ...interface{}) int64 {
-	count, err := dbmap.UpdateColumns(context.Background(), filter, list...)
 	if err != nil {
 		panic(err)
 	}

--- a/table_bindings.go
+++ b/table_bindings.go
@@ -26,13 +26,6 @@ type CustomScanner struct {
 	Binder func(holder interface{}, target interface{}) error
 }
 
-// Used to filter columns when selectively updating
-type ColumnFilter func(*ColumnMap) bool
-
-func acceptAllFilter(col *ColumnMap) bool {
-	return true
-}
-
 // Bind is called automatically by gorp after Scan()
 func (me CustomScanner) Bind() error {
 	return me.Binder(me.Holder, me.Target)
@@ -161,11 +154,7 @@ func (t *TableMap) bindInsert(elem reflect.Value) (bindInstance, error) {
 	return plan.createBindInstance(elem, t.dbmap.TypeConverter)
 }
 
-func (t *TableMap) bindUpdate(elem reflect.Value, colFilter ColumnFilter) (bindInstance, error) {
-	if colFilter == nil {
-		colFilter = acceptAllFilter
-	}
-
+func (t *TableMap) bindUpdate(elem reflect.Value) (bindInstance, error) {
 	plan := &t.updatePlan
 	plan.once.Do(func() {
 		s := bytes.Buffer{}
@@ -174,7 +163,7 @@ func (t *TableMap) bindUpdate(elem reflect.Value, colFilter ColumnFilter) (bindI
 
 		for y := range t.Columns {
 			col := t.Columns[y]
-			if !col.isAutoIncr && !col.Transient && colFilter(col) {
+			if !col.isAutoIncr && !col.Transient {
 				if x > 0 {
 					s.WriteString(", ")
 				}

--- a/transaction.go
+++ b/transaction.go
@@ -27,12 +27,7 @@ func (t *Transaction) Insert(ctx context.Context, list ...interface{}) error {
 
 // Update had the same behavior as DbMap.Update(), but runs in a transaction.
 func (t *Transaction) Update(ctx context.Context, list ...interface{}) (int64, error) {
-	return update(ctx, t.dbmap, t, nil, list...)
-}
-
-// UpdateColumns had the same behavior as DbMap.UpdateColumns(), but runs in a transaction.
-func (t *Transaction) UpdateColumns(ctx context.Context, filter ColumnFilter, list ...interface{}) (int64, error) {
-	return update(ctx, t.dbmap, t, filter, list...)
+	return update(ctx, t.dbmap, t, list...)
 }
 
 // Delete has the same behavior as DbMap.Delete(), but runs in a transaction.


### PR DESCRIPTION
Fixes #15.

This removes the unused `UpdateColumns` API and the related `ColumnFilter` plumbing. Boulder does not use this API, and removing it avoids preserving the cached filtered-update behavior reported in #15.

The change deletes `DbMap.UpdateColumns`, `Transaction.UpdateColumns`, `ColumnFilter`, the internal filtered update path, and the column-filter test/helper.

Verification:

- `go test . -count=1`
- `go test ./... -count=1`
- `go vet ./...`
- `go test -race ./... -count=1`
- `git diff --check`

I also checked Boulder application code for `UpdateColumns` / `ColumnFilter`; the only hits were in Boulder’s vendored borp copy.